### PR TITLE
remove unnecessary options un navbar

### DIFF
--- a/src/app/components/shared/user/user.component.css
+++ b/src/app/components/shared/user/user.component.css
@@ -1,3 +1,7 @@
 .help-color {
     color: white;
 }
+
+.dropdown-menu {
+  margin: 0 1rem;
+}

--- a/src/app/components/shared/user/user.component.html
+++ b/src/app/components/shared/user/user.component.html
@@ -1,40 +1,9 @@
-<div class="row">
-    <div class="col-md-2">
-        <a class="nav-link dropdown-toggle help-color" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <i class="fas fa-question-circle"></i>
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <a class="dropdown-item">Getting Started Guie</a>
-            <a class="dropdown-item">Product Help</a>
-            <a class="dropdown-item">Suggest Idea</a>
-            <a class="dropdown-item">What's New</a>
-        </div>
-    </div>
+<div>
+  <a class="nav-link dropdown-toggle help-color" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <i class="far fa-user-circle"></i> Dario Herrera
+  </a>
 
-    <div class="col-md-2">
-        <a class="nav-link dropdown-toggle help-color" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <i class="far fa-bell"></i>
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <a class="dropdown-item">Notifications</a>
-            <div class="dropdown-divider"></div>
-            <p class="text-center"> Empty </p>
-        </div>
-    </div>
-
-    <div class="col-md-5">
-
-        <a class="nav-link dropdown-toggle help-color" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <i class="far fa-user-circle"></i> Dario Herrera
-        </a>
-
-        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <a class="dropdown-item">Profile user</a>
-            <div class="dropdown-divider"></div>
-            <a class="dropdown-item">Time clock</a>
-            <a class="dropdown-item">Profile</a>
-            <a class="dropdown-item">Support tools</a>
-            <a class="dropdown-item">Sign Out</a>
-
-        </div>
-    </div>
+  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+    <a class="dropdown-item">Sign Out</a>
+  </div>
+</div>


### PR DESCRIPTION
Removed the bell and help icons and remove some options into the dropdown
Fix the overlapping in dropdown options over navbar.

<img width="231" alt="Captura de Pantalla 2020-03-24 a la(s) 6 05 15 p  m" src="https://user-images.githubusercontent.com/14335336/77485096-4bd93880-6dfa-11ea-9096-67a0d9d04306.png">
