### PR TITLE
Fix some issues

### DIFF
--- a/src/app/modules/reports/components/time-range-form/time-range-form.component.ts
+++ b/src/app/modules/reports/components/time-range-form/time-range-form.component.ts
@@ -23,7 +23,8 @@ export class TimeRangeFormComponent {
   onSubmit() {
     this.store.dispatch(new entryActions.LoadEntriesByTimeRange({
       start_date: this.startDate.value,
-      end_date: this.endDate.value
+      end_date: this.endDate.value,
+      user_id: '*',
     }));
   }
 }

--- a/src/app/modules/reports/components/time-range-form/time-range.component.spec.ts
+++ b/src/app/modules/reports/components/time-range-form/time-range.component.spec.ts
@@ -67,6 +67,7 @@ describe('Reports Page', () => {
       expect(store.dispatch).toHaveBeenCalledWith(new entryActions.LoadEntriesByTimeRange({
         start_date: startDateValue,
         end_date: endDateValue,
+        user_id: '*',
       }));
     });
 

--- a/src/app/modules/time-clock/components/entry-fields/entry-fields.component.html
+++ b/src/app/modules/time-clock/components/entry-fields/entry-fields.component.html
@@ -4,6 +4,7 @@
       <span class="input-group-text span-width">Activity</span>
     </div>
     <select id="activitiesSelect" (blur)="onSubmit()" class="form-control" formControlName="activity_id">
+      <option value="-1"></option>
       <option *ngFor="let activity of activities" value="{{activity.id}}">{{ activity.name }}</option>
     </select>
   </div>

--- a/src/app/modules/time-clock/components/entry-fields/entry-fields.component.ts
+++ b/src/app/modules/time-clock/components/entry-fields/entry-fields.component.ts
@@ -29,7 +29,7 @@ export class EntryFieldsComponent implements OnInit {
     this.entryForm = this.formBuilder.group({
       description: '',
       uri: '',
-      activity_id: ''
+      activity_id: '-1'
     });
   }
 
@@ -38,8 +38,11 @@ export class EntryFieldsComponent implements OnInit {
     const activities$ = this.store.pipe(select(allActivities));
     activities$.subscribe((response) => {
       this.activities = response;
+      this.loadActiveEntry();
     });
+  }
 
+  loadActiveEntry() {
     const activeEntry$ = this.store.pipe(select(getActiveTimeEntry));
     activeEntry$.subscribe((response) => {
       if (response) {

--- a/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
+++ b/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
@@ -61,5 +61,6 @@ export class ProjectListHoverComponent implements OnInit {
       const newEntry = { project_id: selectedProject, start_date: new Date().toISOString() };
       this.store.dispatch(new entryActions.CreateEntry(newEntry));
     }
+    this.store.dispatch(new entryActions.LoadEntries(new Date().getMonth() + 1 ));
   }
 }

--- a/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
+++ b/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
@@ -31,8 +31,8 @@ export class ProjectListHoverComponent implements OnInit {
     const projects$ = this.store.pipe(select(getProjects));
     projects$.subscribe((projects) => {
       this.listProjects = projects;
+      this.loadActiveTimeEntry();
     });
-    this.loadActiveTimeEntry();
   }
 
   private loadActiveTimeEntry() {

--- a/src/app/modules/time-clock/models/time-entries-time-range.ts
+++ b/src/app/modules/time-clock/models/time-entries-time-range.ts
@@ -1,4 +1,5 @@
 export interface TimeEntriesTimeRange {
   start_date: Date;
   end_date: Date;
+  user_id: string;
 }

--- a/src/app/modules/time-clock/services/entry.service.spec.ts
+++ b/src/app/modules/time-clock/services/entry.service.spec.ts
@@ -92,7 +92,7 @@ describe('EntryService', () => {
     const startDateValue = new Date();
     const endDateValue = new Date();
     const pipe: DatePipe = new DatePipe('en');
-    const timeRange: TimeEntriesTimeRange = {start_date: startDateValue, end_date: endDateValue};
+    const timeRange: TimeEntriesTimeRange = {start_date: startDateValue, end_date: endDateValue, user_id: '*'};
 
     service.loadEntriesByTimeRange(timeRange).subscribe();
 

--- a/src/app/modules/time-clock/services/entry.service.ts
+++ b/src/app/modules/time-clock/services/entry.service.ts
@@ -55,7 +55,8 @@ export class EntryService {
       {
         params: {
           start_date: this.datePipe.transform(range.start_date, EntryService.TIME_ENTRIES_DATE_TIME_FORMAT),
-          end_date: this.datePipe.transform(range.end_date, EntryService.TIME_ENTRIES_DATE_TIME_FORMAT)
+          end_date: this.datePipe.transform(range.end_date, EntryService.TIME_ENTRIES_DATE_TIME_FORMAT),
+          user_id: range.user_id
         }
       }
     );

--- a/src/app/modules/time-clock/store/entry.effects.spec.ts
+++ b/src/app/modules/time-clock/store/entry.effects.spec.ts
@@ -34,8 +34,27 @@ describe('TimeEntryActionEffects', () => {
     expect(effects).toBeTruthy();
   });
 
+  it('returns an action with type LOAD_ENTRIES_SUMMARY_SUCCESS when the service returns a value',  () => {
+    actions$ = of({type: EntryActionTypes.LOAD_ENTRIES_SUMMARY});
+    const serviceSpy = spyOn(service, 'summary');
+    serviceSpy.and.returnValue(of({}));
+
+    effects.loadEntriesSummary$.subscribe(action => {
+      expect(action.type).toEqual(EntryActionTypes.LOAD_ENTRIES_SUMMARY_SUCCESS);
+    });
+  });
+
+  it('returns an action with type LOAD_ENTRIES_SUMMARY_FAIL when the service fails',  () => {
+    actions$ = of({type: EntryActionTypes.LOAD_ENTRIES_SUMMARY});
+    spyOn(service, 'summary').and.returnValue(throwError('any error'));
+
+    effects.loadEntriesSummary$.subscribe(action => {
+      expect(action.type).toEqual(EntryActionTypes.LOAD_ENTRIES_SUMMARY_FAIL);
+    });
+  });
+
   it('When the service returns a value, then LOAD_ENTRIES_BY_TIME_RANGE_SUCCESS should be triggered',  () => {
-    const timeRange: TimeEntriesTimeRange = {start_date: new Date(), end_date: new Date()};
+    const timeRange: TimeEntriesTimeRange = {start_date: new Date(), end_date: new Date(), user_id: '*' };
     actions$ = of({type: EntryActionTypes.LOAD_ENTRIES_BY_TIME_RANGE, timeRange});
     const serviceSpy = spyOn(service, 'loadEntriesByTimeRange');
     serviceSpy.and.returnValue(of([]));
@@ -47,7 +66,7 @@ describe('TimeEntryActionEffects', () => {
   });
 
   it('When the service fails, then LOAD_ENTRIES_BY_TIME_RANGE_FAIL should be triggered', async () => {
-      const timeRange: TimeEntriesTimeRange = {start_date: new Date(), end_date: new Date()};
+      const timeRange: TimeEntriesTimeRange = {start_date: new Date(), end_date: new Date(), user_id: '*'};
       actions$ = of({type: EntryActionTypes.LOAD_ENTRIES_BY_TIME_RANGE, timeRange});
       spyOn(service, 'loadEntriesByTimeRange').and.returnValue(throwError('any error'));
 

--- a/src/app/modules/time-clock/store/entry.reducer.ts
+++ b/src/app/modules/time-clock/store/entry.reducer.ts
@@ -153,7 +153,7 @@ export const entryReducer = (state: EntryState = initialState, action: EntryActi
       const entryList = [...state.entryList];
       const index = entryList.findIndex((entry) => entry.id === action.payload.id);
       entryList[index] = action.payload;
-      entryList.sort((a, b) => b.start_date.getTime() - a.start_date.getTime());
+      entryList.sort((a, b) => new Date(b.start_date).getTime() - new Date(a.start_date).getTime());
       return {
         ...state,
         isLoading: false,

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -1,3 +1,4 @@
+import { getActiveTimeEntry } from './../../time-clock/store/entry.selectors';
 import { ToastrService } from 'ngx-toastr';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideMockStore, MockStore } from '@ngrx/store/testing';
@@ -232,4 +233,21 @@ describe('TimeEntriesComponent', () => {
     component.getMonth(month);
     expect(store.dispatch).toHaveBeenCalledWith(new entryActions.LoadEntries(month));
   });
+
+
+  it('doSave when activeTimeEntry === null', async(() => {
+    const entryToSave = {
+      project_id: 'project-id',
+      start_date: '2010-05-05T10:04',
+      description: 'description',
+      technologies: [],
+      uri: 'abc',
+    };
+    spyOn(component, 'doSave');
+    component.activeTimeEntry = null;
+
+    component.saveEntry(entryToSave);
+
+    expect(component.doSave).toHaveBeenCalledWith(entryToSave);
+  }));
 });

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -56,6 +56,7 @@ export class TimeEntriesComponent implements OnInit {
     } else {
       this.doSave(entry);
     }
+    this.store.dispatch(new entryActions.LoadEntries(new Date().getMonth() + 1));
   }
 
   doSave(entry) {
@@ -65,7 +66,6 @@ export class TimeEntriesComponent implements OnInit {
     } else {
       this.store.dispatch(new entryActions.CreateEntry(entry));
     }
-    this.store.dispatch(new entryActions.LoadEntries(new Date().getMonth() + 1));
   }
 
   removeEntry(entryId: string) {

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -65,6 +65,7 @@ export class TimeEntriesComponent implements OnInit {
     } else {
       this.store.dispatch(new entryActions.CreateEntry(entry));
     }
+    this.store.dispatch(new entryActions.LoadEntries(new Date().getMonth() + 1));
   }
 
   removeEntry(entryId: string) {


### PR DESCRIPTION
closes #329 reload entries after clock-in
closes #274 sets the right project id on time-clock screen
closes #327 modal is closed after updating the information
closes #325 adds a wildcard to query the entries report
closes #323 sets the activity to blank on time-clock screen