### PR TITLE
fix: :alien: add time_offset query param to summary endpoint

### DIFF
--- a/src/app/modules/time-clock/services/entry.service.spec.ts
+++ b/src/app/modules/time-clock/services/entry.service.spec.ts
@@ -48,10 +48,10 @@ describe('EntryService', () => {
     expect(loadEntryRequest.request.method).toBe('GET');
   });
 
-  it('loads summary with get /summary', () => {
+  it('loads summary with get /summary?time_offset=<time-offset>', () => {
     service.summary().subscribe();
-
-    const loadEntryRequest = httpMock.expectOne(`${service.baseUrl}/summary`);
+    const time_offset = new Date().getTimezoneOffset();
+    const loadEntryRequest = httpMock.expectOne(`${service.baseUrl}/summary?time_offset=${time_offset}`);
     expect(loadEntryRequest.request.method).toBe('GET');
   });
 

--- a/src/app/modules/time-clock/services/entry.service.ts
+++ b/src/app/modules/time-clock/services/entry.service.ts
@@ -46,7 +46,8 @@ export class EntryService {
   }
 
   summary(): Observable<TimeEntriesSummary> {
-    const summaryUrl = `${this.baseUrl}/summary`;
+    const time_offset = new Date().getTimezoneOffset();
+    const summaryUrl = `${this.baseUrl}/summary?time_offset=${time_offset}`;
     return this.http.get<TimeEntriesSummary>(summaryUrl);
   }
 


### PR DESCRIPTION
fixes #358 