### PR TITLE
feat: #447 Updating the date format on the report page

### DIFF
--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.html
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.html
@@ -19,7 +19,7 @@
         *ngFor="let entry of data"
       >
         <td class="col md-col multiline-col"> {{ entry.owner_email }} </td>
-        <td class="col sm-col"> {{ entry.start_date | date: 'dd/MM/yyyy' }} </td>
+        <td class="col sm-col"> {{ entry.start_date | date: 'MM/dd/yyyy' }} </td>
         <td class="col sm-col"> {{ entry.end_date | substractDate: entry.start_date }} </td>
         <td class="col md-col"> {{ entry.project_name }} </td>
         <td class="col md-col"> {{ entry.activity_name }} </td>

--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
@@ -12,9 +12,7 @@ import {DataTableDirective} from 'angular-datatables';
   styleUrls: ['./time-entries-table.component.scss']
 })
 export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewInit {
-
   data = [];
-  const;
   dtOptions: any = {
     scrollY: '600px',
     paging: false,
@@ -25,12 +23,12 @@ export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewIn
       {
         extend: 'excel',
         text: 'Excel',
-        filename: `time-entries-${ formatDate(new Date(), 'yyyy_MM_dd-hh_mm', 'en') }`
+        filename: `time-entries-${ formatDate(new Date(), 'MM_dd_yyyy-HH_mm', 'en') }`
       },
       {
         extend: 'csv',
         text: 'CSV',
-        filename: `time-entries-${ formatDate(new Date(), 'yyyy_MM_dd-hh_mm', 'en') }`
+        filename: `time-entries-${formatDate(new Date(), 'MM_dd_yyyy-HH_mm', 'en') }`
       }
     ]
   };


### PR DESCRIPTION
It updates the Date format on the report page.
Now dates are displayed following this pattern: `MM/dd/yyyy`
![image](https://user-images.githubusercontent.com/9062908/86267582-8afeee80-bb8c-11ea-8a07-b37e7bfb8720.png)
**Note** The number of rows displayed should be checked in the backend side since it is limiting the amount of data sent to the frontend