### PR TITLE
TT-64 fix: set technologies as list when create time-entry

### DIFF
--- a/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
+++ b/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
@@ -88,6 +88,7 @@ export class ProjectListHoverComponent implements OnInit, OnDestroy {
       project_id: selectedProject,
       start_date: new Date().toISOString(),
       timezone_offset: new Date().getTimezoneOffset(),
+      technologies: []
     };
     this.store.dispatch(new entryActions.ClockIn(entry));
     this.projectsForm.setValue( { project_id: `${customerName} - ${name}`, } );

--- a/src/app/modules/time-clock/store/entry.effects.ts
+++ b/src/app/modules/time-clock/store/entry.effects.ts
@@ -25,6 +25,7 @@ export class EntryEffects {
             project_id: action.idProjectSwitching,
             start_date: stopDateForEntry.toISOString(),
             timezone_offset: new Date().getTimezoneOffset(),
+            technologies: []
           };
           return new actions.ClockIn(entry);
         }),


### PR DESCRIPTION
With these changes, we ensure that at the moment the time-entry is created, the technologies field is set as an empty list. See TT-64 for details.