### PR TITLE
fix: TT-226 Show user an error message when they try to save a time e…

### DIFF
--- a/src/app/modules/shared/components/details-fields/details-fields.component.spec.ts
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.spec.ts
@@ -576,6 +576,12 @@ describe('DetailsFieldsComponent', () => {
     const foundActivity = component.findInactiveActivity(state.activities.data);
     expect(foundActivity).toEqual(expectedActivity);
   });
+
+  it('should return false when the start time entry is not greater than the end time', () => {
+    const result = component.isStartTimeEntryAfterEndedEntry();
+
+    expect(result).toBeFalse();
+  });
   /*
    TODO As part of https://github.com/ioet/time-tracker-ui/issues/424 a new parameter was added to the details-field-component,
    and now these couple of tests are failing. A solution to this error might be generate a Test Wrapper Component. More details here:

--- a/src/app/modules/shared/components/details-fields/details-fields.component.spec.ts
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.spec.ts
@@ -599,7 +599,7 @@ describe('DetailsFieldsComponent', () => {
       expected_result: false,
     },
   ];
-  datesParams.map((param) => {
+  datesParams.forEach((param) => {
     it(`${param.case}`, () => {
       component.entryForm.setValue({ ...formValues, ...param.entryDates });
       const result = component.isStartTimeEntryAfterEndedEntry();

--- a/src/app/modules/shared/components/details-fields/details-fields.component.spec.ts
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.spec.ts
@@ -577,10 +577,35 @@ describe('DetailsFieldsComponent', () => {
     expect(foundActivity).toEqual(expectedActivity);
   });
 
-  it('should return false when the start time entry is not greater than the end time', () => {
-    const result = component.isStartTimeEntryAfterEndedEntry();
+  const datesParams = [
+    {
+      case: 'should return true when the start time entry is greater than the end time',
+      entryDates: {
+        start_date: '2021-04-21',
+        end_date: '2021-04-21',
+        start_hour: '20:00',
+        end_hour: '08:00',
+      },
+      expected_result: true,
+    },
+    {
+      case: 'should return false when the start time entry is not greater than the end time',
+      entryDates: {
+        start_date: '2021-04-21',
+        end_date: '2021-04-21',
+        start_hour: '19:00',
+        end_hour: '20:00',
+      },
+      expected_result: false,
+    },
+  ];
+  datesParams.map((param) => {
+    it(`${param.case}`, () => {
+      component.entryForm.setValue({ ...formValues, ...param.entryDates });
+      const result = component.isStartTimeEntryAfterEndedEntry();
 
-    expect(result).toBeFalse();
+      expect(result).toBe(param.expected_result);
+    });
   });
   /*
    TODO As part of https://github.com/ioet/time-tracker-ui/issues/424 a new parameter was added to the details-field-component,

--- a/src/app/modules/shared/components/details-fields/details-fields.component.ts
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.ts
@@ -244,6 +244,12 @@ export class DetailsFieldsComponent implements OnChanges, OnInit {
     this.closeModal?.nativeElement?.click();
   }
 
+  isStartTimeEntryAfterEndedEntry(): boolean {
+    const startDate = moment(`${this.start_date.value} ${this.start_hour.value}`);
+    const endDate = moment(`${this.end_date.value} ${this.end_hour.value}`);
+    return startDate >= endDate;
+  }
+
   dateToSubmit(date, hour) {
     const entryFormDate = this.entryForm.value[date];
     const updatedHour = this.entryForm.value[hour];
@@ -263,6 +269,11 @@ export class DetailsFieldsComponent implements OnChanges, OnInit {
 
     const startDateToSubmit = this.dateToSubmit('start_date', 'start_hour');
     const endDateToSubmit = this.dateToSubmit('end_date', 'end_hour');
+
+    if (this.isStartTimeEntryAfterEndedEntry()) {
+      this.toastrService.error('You must end the time entry after it started');
+      return;
+    }
 
     const entry = {
       project_id: this.entryForm.value.project_id,


### PR DESCRIPTION
[TT-226](https://ioetec.atlassian.net/browse/TT-226)

This PR implement 'When the user tries to save, an error message should be shown that the clock out time can’t be before the clock in time'.