### PR TITLE
feat: TT-19 Create Cookies of FeatureToggle

### DIFF
--- a/src/app/modules/login/login.component.spec.ts
+++ b/src/app/modules/login/login.component.spec.ts
@@ -5,11 +5,14 @@ import { of } from 'rxjs';
 
 import { LoginComponent } from './login.component';
 import { Router } from '@angular/router';
+import { FeatureToggleCookiesService } from '../shared/feature-toggles/feature-toggle-cookies/feature-toggle-cookies.service';
+import { promise } from 'selenium-webdriver';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
   let azureAdB2CService: AzureAdB2CService;
+  let featureToggleCookiesService: FeatureToggleCookiesService;
 
   const azureAdB2CServiceStub = {
     isLogin() {
@@ -22,12 +25,19 @@ describe('LoginComponent', () => {
     }
   };
 
+  const featureToggleCookiesServiceStub = {
+    setCookies() {
+    }
+  };
+
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [ RouterTestingModule ],
       declarations: [ LoginComponent ],
       providers: [
-        { providers: AzureAdB2CService, useValue: azureAdB2CServiceStub}
+        { providers: AzureAdB2CService, useValue: azureAdB2CServiceStub},
+        { providers: FeatureToggleCookiesService, useValue: featureToggleCookiesServiceStub}
       ]
     })
     .compileComponents();
@@ -38,12 +48,18 @@ describe('LoginComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
     azureAdB2CService = TestBed.inject(AzureAdB2CService);
-
+    featureToggleCookiesService = TestBed.inject(FeatureToggleCookiesService);
   });
 
-  it('Service injected via inject(...) and TestBed.get(...) should be the same instance',
+  it('AzureAdB2CService injected via inject(...) and TestBed.get(...) should be the same instance',
     inject([AzureAdB2CService], (injectService: AzureAdB2CService) => {
       expect(injectService).toEqual(azureAdB2CService);
+    })
+  );
+
+  it('FeatureToggleCookiesService injected via inject(...) and TestBed.get(...) should be the same instance',
+    inject([FeatureToggleCookiesService], (injectService: FeatureToggleCookiesService) => {
+      expect(injectService).toEqual(featureToggleCookiesService);
     })
   );
 
@@ -55,9 +71,13 @@ describe('LoginComponent', () => {
     spyOn(azureAdB2CService, 'isLogin').and.returnValue(false);
     spyOn(azureAdB2CService, 'setCookies').and.returnValue();
     spyOn(azureAdB2CService, 'signIn').and.returnValue(of(() => {}));
+    spyOn(featureToggleCookiesService, 'setCookies').and.returnValue(featureToggleCookiesService.setCookies());
+
     component.login();
+
     expect(azureAdB2CService.signIn).toHaveBeenCalled();
     expect(azureAdB2CService.setCookies).toHaveBeenCalled();
+    expect(featureToggleCookiesService.setCookies).toHaveBeenCalled();
   }));
 
   it('should not sign-up or login with google if is already logged-in into the app', inject([Router],  (router: Router) => {

--- a/src/app/modules/login/login.component.spec.ts
+++ b/src/app/modules/login/login.component.spec.ts
@@ -2,11 +2,9 @@ import { waitForAsync, ComponentFixture, TestBed, inject } from '@angular/core/t
 import { RouterTestingModule } from '@angular/router/testing';
 import { AzureAdB2CService } from '../../modules/login/services/azure.ad.b2c.service';
 import { of } from 'rxjs';
-
 import { LoginComponent } from './login.component';
 import { Router } from '@angular/router';
 import { FeatureToggleCookiesService } from '../shared/feature-toggles/feature-toggle-cookies/feature-toggle-cookies.service';
-import { promise } from 'selenium-webdriver';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
@@ -27,9 +25,9 @@ describe('LoginComponent', () => {
 
   const featureToggleCookiesServiceStub = {
     setCookies() {
+      return null;
     }
   };
-
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({

--- a/src/app/modules/login/login.component.ts
+++ b/src/app/modules/login/login.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { AzureAdB2CService } from './services/azure.ad.b2c.service';
 import { Router } from '@angular/router';
+import { FeatureToggleCookiesService } from '../shared/feature-toggles/feature-toggle-cookies/feature-toggle-cookies.service';
 
 @Component({
   selector: 'app-login',
@@ -10,13 +11,18 @@ import { Router } from '@angular/router';
 
 export class LoginComponent {
 
-  constructor(private azureAdB2CService: AzureAdB2CService, private router: Router) {}
+  constructor(
+    private azureAdB2CService: AzureAdB2CService,
+    private router: Router,
+    private featureToggleCookiesService: FeatureToggleCookiesService
+  ) {}
 
   login(): void {
     if (this.azureAdB2CService.isLogin()) {
       this.router.navigate(['']);
     } else {
       this.azureAdB2CService.signIn().subscribe(() => {
+        this.featureToggleCookiesService.setCookies();
         this.azureAdB2CService.setCookies();
         this.router.navigate(['']);
       });

--- a/src/app/modules/login/services/azure.ad.b2c.service.spec.ts
+++ b/src/app/modules/login/services/azure.ad.b2c.service.spec.ts
@@ -44,9 +44,12 @@ describe('AzureAdB2CService', () => {
 
   it('on logout should call msal logout and verify if user localStorage is removed', () => {
     spyOn(UserAgentApplication.prototype, 'logout').and.returnValue();
+    spyOn(cookieService, 'deleteAll');
     spyOn(localStorage, 'removeItem').withArgs('user');
+
     service.logout();
 
+    expect(cookieService.deleteAll).toHaveBeenCalled();
     expect(localStorage.removeItem).toHaveBeenCalledWith('user');
     expect(UserAgentApplication.prototype.logout).toHaveBeenCalled();
   });

--- a/src/app/modules/login/services/azure.ad.b2c.service.ts
+++ b/src/app/modules/login/services/azure.ad.b2c.service.ts
@@ -32,8 +32,7 @@ export class AzureAdB2CService {
   }
 
   logout() {
-    this.cookieService.delete('msal.idtoken');
-    this.cookieService.delete('msal.client.info');
+    this.cookieService.deleteAll();
     this.msal.logout();
     localStorage.removeItem('user');
   }

--- a/src/app/modules/shared/feature-toggles/feature-toggle-cookies/feature-toggle-cookies.service.spec.ts
+++ b/src/app/modules/shared/feature-toggles/feature-toggle-cookies/feature-toggle-cookies.service.spec.ts
@@ -1,0 +1,67 @@
+import { TestBed } from '@angular/core/testing';
+import { CookieService } from 'ngx-cookie-service';
+import { of } from 'rxjs';
+import { FeatureToggleGeneralService } from '../feature-toggle-general/feature-toggle-general.service';
+import { FeatureToggleModel } from '../feature-toggle.model';
+import { TargetingFeatureFilterModel } from '../filters/targeting/targeting-feature-filter.model';
+import { FeatureToggleCookiesService } from './feature-toggle-cookies.service';
+
+describe('FeatureToggleCookiesService', () => {
+  let cookieService: CookieService;
+  let featureToggleGeneralService: FeatureToggleGeneralService;
+  let service: FeatureToggleCookiesService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [CookieService, FeatureToggleGeneralService]
+    });
+    cookieService = TestBed.inject(CookieService);
+    featureToggleGeneralService = TestBed.inject(FeatureToggleGeneralService);
+    service = TestBed.inject(FeatureToggleCookiesService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('not call CookieService.set() when call setCookies() and getActivated() return empty', () => {
+    const fakeAllFeatureaToggleWithFilters = [];
+    const spyOnSetCookie = spyOn(cookieService, 'set');
+    spyOn(featureToggleGeneralService, 'getActivated').and.returnValue(of(fakeAllFeatureaToggleWithFilters));
+
+    service.setCookies();
+
+    expect(spyOnSetCookie).toHaveBeenCalledTimes(0);
+  });
+
+  it('Call 1 time CookieService.set() when call setCookies()', () => {
+    const anyMatchingFilter = new TargetingFeatureFilterModel(
+      { Audience: { Groups: ['group-a'], Users: ['user-a'] } },
+      { username: 'user-b', group: 'group-a' }
+    );
+    const fakeAllFeatureaToggleWithFilters = [new FeatureToggleModel('any-other-id', true, [anyMatchingFilter])];
+    const spyOnSetCookie = spyOn(cookieService, 'set');
+    spyOn(featureToggleGeneralService, 'getActivated').and.returnValue(of(fakeAllFeatureaToggleWithFilters));
+
+    service.setCookies();
+
+    expect(spyOnSetCookie).toHaveBeenCalledTimes(1);
+  });
+
+  it('Call 2 times CookieService.set() when call setCookies()', () => {
+    const anyMatchingFilter = new TargetingFeatureFilterModel(
+      { Audience: { Groups: ['group-a'], Users: ['user-a'] } },
+      { username: 'user-b', group: 'group-a' }
+    );
+    const fakeAllFeatureaToggleWithFilters = [
+      new FeatureToggleModel('first-id', true, [anyMatchingFilter]),
+      new FeatureToggleModel('second-id', true, [anyMatchingFilter])
+    ];
+    const spyOnSetCookie = spyOn(cookieService, 'set');
+    spyOn(featureToggleGeneralService, 'getActivated').and.returnValue(of(fakeAllFeatureaToggleWithFilters));
+
+    service.setCookies();
+
+    expect(spyOnSetCookie).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/modules/shared/feature-toggles/feature-toggle-cookies/feature-toggle-cookies.service.ts
+++ b/src/app/modules/shared/feature-toggles/feature-toggle-cookies/feature-toggle-cookies.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { FeatureToggleGeneralService } from '../feature-toggle-general/feature-toggle-general.service';
+import { CookieService } from 'ngx-cookie-service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FeatureToggleCookiesService {
+
+  constructor(
+    private cookieService: CookieService,
+    private featureToggleGeneralService: FeatureToggleGeneralService
+  ) { }
+
+  setCookies(){
+    this.featureToggleGeneralService.getActivated().subscribe(
+      (allFeaturToggle) => {
+        for (const featureToggle of allFeaturToggle){
+          this.cookieService.set(featureToggle.name, `${featureToggle.enabled}`, 30);
+        }
+      }
+    );
+  }
+}

--- a/src/app/modules/shared/feature-toggles/feature-toggle-general/feature-toggle-general.service.spec.ts
+++ b/src/app/modules/shared/feature-toggles/feature-toggle-general/feature-toggle-general.service.spec.ts
@@ -48,7 +48,6 @@ describe('FeatureToggleGeneralService', () => {
       expect(featureToggleEnableForUser.length).toEqual(1);
       expect(featureToggleEnableForUser).toEqual(fakeAllFeatureaToggleWithFilters);
     });
-
   });
 
   it('getActivated return empty', () => {
@@ -59,6 +58,5 @@ describe('FeatureToggleGeneralService', () => {
       expect(featureToggleEnableForUser.length).toEqual(0);
       expect(featureToggleEnableForUser).toEqual(fakeAllFeatureaToggleWithFilters);
     });
-
   });
 });

--- a/src/app/modules/shared/feature-toggles/feature-toggle-general/feature-toggle-general.service.spec.ts
+++ b/src/app/modules/shared/feature-toggles/feature-toggle-general/feature-toggle-general.service.spec.ts
@@ -1,8 +1,10 @@
 import { FeatureToggle } from './../../../../../environments/enum';
 import { TestBed } from '@angular/core/testing';
-import { of, Observable } from 'rxjs';
+import { of } from 'rxjs';
 import { FeatureManagerService } from '../feature-toggle-manager.service';
 import { FeatureToggleGeneralService } from './feature-toggle-general.service';
+import { FeatureToggleModel } from '../feature-toggle.model';
+import { TargetingFeatureFilterModel } from '../filters/targeting/targeting-feature-filter.model';
 
 
 describe('FeatureToggleGeneralService', () => {
@@ -32,5 +34,31 @@ describe('FeatureToggleGeneralService', () => {
         expect(enabled).toBe(param.bool);
       });
     });
+  });
+
+  it('getActivated return a FeatureToggleModel', () => {
+    const anyNotMatchingFilter = new TargetingFeatureFilterModel(
+      { Audience: { Groups: ['a-group'], Users: ['user-a'] } },
+      { username: 'user-b', group: 'b-group' }
+    );
+    const fakeAllFeatureaToggleWithFilters = [new FeatureToggleModel('any-other-id', true, [anyNotMatchingFilter])];
+    spyOn(featureManagerService, 'getAllFeatureToggleEnableForUser').and.returnValue(of(fakeAllFeatureaToggleWithFilters));
+
+    featureToggleGeneralService.getActivated().subscribe((featureToggleEnableForUser) => {
+      expect(featureToggleEnableForUser.length).toEqual(1);
+      expect(featureToggleEnableForUser).toEqual(fakeAllFeatureaToggleWithFilters);
+    });
+
+  });
+
+  it('getActivated return empty', () => {
+    const fakeAllFeatureaToggleWithFilters = [];
+    spyOn(featureManagerService, 'getAllFeatureToggleEnableForUser').and.returnValue(of(fakeAllFeatureaToggleWithFilters));
+
+    featureToggleGeneralService.getActivated().subscribe((featureToggleEnableForUser) => {
+      expect(featureToggleEnableForUser.length).toEqual(0);
+      expect(featureToggleEnableForUser).toEqual(fakeAllFeatureaToggleWithFilters);
+    });
+
   });
 });

--- a/src/app/modules/shared/feature-toggles/feature-toggle-general/feature-toggle-general.service.ts
+++ b/src/app/modules/shared/feature-toggles/feature-toggle-general/feature-toggle-general.service.ts
@@ -3,6 +3,7 @@ import { FeatureToggle } from './../../../../../environments/enum';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { FeatureManagerService } from '../feature-toggle-manager.service';
+import { FeatureToggleModel } from '../feature-toggle.model';
 
 @Injectable({
   providedIn: 'root',
@@ -12,5 +13,9 @@ export class FeatureToggleGeneralService {
 
   isActivated(featureToggle: FeatureToggle): Observable<boolean> {
     return this.featureManagerService.isToggleEnabledForUser(featureToggle);
+  }
+
+  getActivated(): Observable<FeatureToggleModel[]>{
+    return this.featureManagerService.getAllFeatureToggleEnableForUser();
   }
 }

--- a/src/app/modules/shared/feature-toggles/feature-toggle-manager.service.spec.ts
+++ b/src/app/modules/shared/feature-toggles/feature-toggle-manager.service.spec.ts
@@ -91,5 +91,48 @@ describe('FeatureToggleManager', () => {
         expect(value).toEqual(false);
       });
     });
+
+    it('Get empty when getAllFeatureToggle() return empty', () => {
+      const fakeAllFeatureaToggleWithFilters = [];
+      spyOn(fakeFeatureToggleProvider, 'getAllFeatureToggle').and.returnValue(Promise.resolve(fakeAllFeatureaToggleWithFilters));
+
+      const response = service.getAllFeatureToggleEnableForUser();
+
+      response.subscribe((result) => {
+        expect(result.length).toEqual(0);
+        expect(result).toEqual([]);
+      });
+      expect().nothing();
+    });
+
+    it('Get empty when getAllFeatureToggle() return FeatureToggle without fakeuser', () => {
+      const fakeAllFeatureaToggleWithFilters = [new FeatureToggleModel('any-other-id', true, [anyNotMatchingFilter])];
+      spyOn(fakeFeatureToggleProvider, 'getAllFeatureToggle').and.returnValue(Promise.resolve(fakeAllFeatureaToggleWithFilters));
+
+      const response = service.getAllFeatureToggleEnableForUser();
+
+      response.subscribe((result) => {
+        expect(result.length).toEqual(0);
+        expect(result).toEqual([]);
+      });
+      expect().nothing();
+    });
+
+    it('Get FeatureToggleModel[] when getAllFeatureToggle() return FeatureToggle with fakeuser', () => {
+      const fakeFeatureToggleModel: FeatureToggleModel = new FeatureToggleModel('good-other-id', false, [anyMatchingFilter]);
+      const fakeAllFeatureaToggleWithFilters = [
+        new FeatureToggleModel('any-other-id', true, [anyNotMatchingFilter]),
+        fakeFeatureToggleModel
+      ];
+      spyOn(fakeFeatureToggleProvider, 'getAllFeatureToggle').and.returnValue(Promise.resolve(fakeAllFeatureaToggleWithFilters));
+
+      const response = service.getAllFeatureToggleEnableForUser();
+
+      response.subscribe((result) => {
+        expect(result.length).toEqual(1);
+        expect(result[0]).toEqual(fakeFeatureToggleModel);
+      });
+      expect().nothing();
+    });
   });
 });

--- a/src/app/modules/shared/feature-toggles/feature-toggle-manager.service.ts
+++ b/src/app/modules/shared/feature-toggles/feature-toggle-manager.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
-import { Observable, zip } from 'rxjs';
+import { from, Observable, zip } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { FeatureToggleProvider } from './feature-toggle-provider.service';
-
+import { FeatureToggleModel } from './feature-toggle.model';
 
 @Injectable({
   providedIn: 'root',
@@ -12,9 +12,9 @@ export class FeatureManagerService {
   constructor(private featureToggleProvider: FeatureToggleProvider) { }
 
   public isToggleEnabled(toggleName: string, toggleLabel?: string): Observable<boolean> {
-    return this.featureToggleProvider.getFeatureToggle(toggleName, toggleLabel).pipe(
-      map(featureToggle => featureToggle.enabled)
-    );
+    return this.featureToggleProvider
+      .getFeatureToggle(toggleName, toggleLabel)
+      .pipe(map((featureToggle) => featureToggle.enabled));
   }
 
   public isToggleEnabledForUser(toggleName: string, toggleLabel?: string): Observable<boolean> {
@@ -34,5 +34,15 @@ export class FeatureManagerService {
     );
 
     return result$;
+  }
+
+  public getAllFeatureToggleEnableForUser(): Observable<FeatureToggleModel[]> {
+    return from(this.featureToggleProvider.getAllFeatureToggle()).pipe(
+      map((allFeatureToggle) =>
+        allFeatureToggle.filter((featureToggle) =>
+          featureToggle.filters.map((filter) => filter.evaluate()).includes(true)
+        )
+      )
+    );
   }
 }

--- a/src/app/modules/shared/feature-toggles/feature-toggle-provider.service.spec.ts
+++ b/src/app/modules/shared/feature-toggles/feature-toggle-provider.service.spec.ts
@@ -86,7 +86,7 @@ describe('FeatureToggleProvider', () => {
   });
 
   it('toggle model is built', async () => {
-    const getFilterConfigurationSpy = spyOn(fakeFeatureFilterProvider, 'getFilterFromConfiguration').and.returnValue(
+    spyOn(fakeFeatureFilterProvider, 'getFilterFromConfiguration').and.returnValue(
       fakeFeatureFilterModel
     );
 

--- a/src/app/modules/shared/feature-toggles/feature-toggle-provider.service.ts
+++ b/src/app/modules/shared/feature-toggles/feature-toggle-provider.service.ts
@@ -7,34 +7,53 @@ import { FeatureToggleConfiguration } from './feature-toggle-configuration';
 import { FeatureToggleModel } from './feature-toggle.model';
 import { FeatureFilterProvider } from './filters/feature-filter-provider.service';
 
-
 const APP_CONFIGURATION_CLIENT = new InjectionToken<AppConfigurationClient>('Azure configuration client', {
   providedIn: 'root',
-  factory: () => new AppConfigurationClient(AZURE_APP_CONFIGURATION_CONNECTION_STRING)
+  factory: () => new AppConfigurationClient(AZURE_APP_CONFIGURATION_CONNECTION_STRING),
 });
 @Injectable({
   providedIn: 'root',
-
 })
 export class FeatureToggleProvider {
   constructor(
     @Inject(APP_CONFIGURATION_CLIENT)
     private client: AppConfigurationClient,
     private featureFilterProvider: FeatureFilterProvider
-  ) { }
+  ) {}
 
   public getFeatureToggle(toggleName: string, toggleLabel?: string): Observable<FeatureToggleModel> {
-    return from(this.client.getConfigurationSetting({ key: `.appconfig.featureflag/${toggleName}`, label: toggleLabel })).pipe(
-      map(featureToggleResponse => JSON.parse(featureToggleResponse.value) as FeatureToggleConfiguration),
-      map(featureToggleConfiguration => {
-        const filters = featureToggleConfiguration.conditions.client_filters.map(filterConfiguration =>
-          this.featureFilterProvider.getFilterFromConfiguration(filterConfiguration));
-        return new FeatureToggleModel(
+    return from(
+      this.client.getConfigurationSetting({ key: `.appconfig.featureflag/${toggleName}`, label: toggleLabel })
+    ).pipe(
+      map((featureToggleResponse) => JSON.parse(featureToggleResponse.value) as FeatureToggleConfiguration),
+      map((featureToggleConfiguration) => {
+        const filters = featureToggleConfiguration.conditions.client_filters.map((filterConfiguration) =>
+          this.featureFilterProvider.getFilterFromConfiguration(filterConfiguration)
+        );
+        return new FeatureToggleModel(featureToggleConfiguration.id, featureToggleConfiguration.enabled, filters);
+      })
+    );
+  }
+
+  public async getAllFeatureToggle(): Promise<FeatureToggleModel[]> {
+    const listFeatureToggleModel: FeatureToggleModel[] = [];
+    const allFeatureToggle = this.client.listConfigurationSettings({ keyFilter: '.appconfig.featureflag/*' });
+    try {
+      for await (const featureToggle of allFeatureToggle) {
+        const featureToggleConfiguration = JSON.parse(featureToggle.value) as FeatureToggleConfiguration;
+        const filters = featureToggleConfiguration.conditions.client_filters.map((filterConfiguration) => {
+          return this.featureFilterProvider.getFilterFromConfiguration(filterConfiguration);
+        });
+        const featureToggleModel = new FeatureToggleModel(
           featureToggleConfiguration.id,
           featureToggleConfiguration.enabled,
-          filters);
+          filters
+        );
+        listFeatureToggleModel.push(featureToggleModel);
       }
-      )
-    );
+      return listFeatureToggleModel;
+    } catch (errorResponseAzure) {
+      return listFeatureToggleModel;
+    }
   }
 }

--- a/src/environments/enum.ts
+++ b/src/environments/enum.ts
@@ -1,4 +1,5 @@
 export enum FeatureToggle {
     SWITCH_GROUP = 'switch-group',
-    UPDATE_ENTRIES = 'update-entries'
+    UPDATE_ENTRIES = 'update-entries',
+    COOKIES = 'feature-toggle-in-cookies'
 }


### PR DESCRIPTION
I solved the task with:

- Add function getAllFeatureToggle() : This method gets all the FeatureToggle of the Azure Endpoint. The Endpoint returns an object of type PagedAsyncIterableIterator, so we use for await to iterate. 
- Add function getAllFeatureToggleEnableForUser() : This method gets all the FeatureToggle from the provider to filter them and return only the Feature Toggle where the user is. 
- Add method getActivated(): This method returns all FeatureToggles enable for user. It use's getAllFeatureToggleEnableForUser() from FeatureManagerService.
- Create  FeatureToggleCookiesService: This services stores all of the user's toggle features in cookies
- Modify all components that it use´s feature toggle: Now, when the component want to know if any feature toggle are enable for the user, it searchs on cookies. 
