### PR TITLE
fix: TT-91 Time out of the penultimate entry overlaps the entry that is running

### DIFF
--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -455,4 +455,30 @@ describe('TimeEntriesComponent', () => {
     component.resetDraggablePosition(dragEndEventStub);
     expect(dragEndEventStub.source._dragRef.reset).toHaveBeenCalled();
   });
+
+  it('component.doSave shouldn´t be called when saving the runningEntry with start_date overlapped', () => {
+    const startDate = new Date(2021, 6, 1, 10, 0);
+    const endDate = new Date(2021, 6, 1, 10, 55);
+    const newRunningEntry = { start_date: endDate, id: '1234', technologies: [], project_name: 'time-tracker', running: true };
+    const newEntry = { start_date: startDate, end_date: endDate, id: '4321', technologies: [], project_name: 'time-tracker'};
+
+    state.timeEntriesDataSource.data = [newRunningEntry, newEntry];
+    component.activeTimeEntry = newRunningEntry;
+    component.entryId = newRunningEntry.id;
+    spyOn(component, 'doSave');
+
+    const startDateModified = new Date(2021, 6, 1, 10, 50);
+    const RunningEntryModified = {
+      entry: {
+        start_date: startDateModified,
+        id: '1234',
+        technologies: ['py'],
+        project_name: 'time-tracker',
+        running: true
+      }, shouldRestartEntry: false
+    };
+    component.saveEntry(RunningEntryModified);
+
+    expect(component.doSave).toHaveBeenCalledTimes(0);
+  });
 });

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -32,6 +32,7 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
   selectedMonth: number;
   selectedYear: number;
   selectedMonthAsText: string;
+  isActiveEntryOverlapping = false;
   constructor(private store: Store<EntryState>, private toastrService: ToastrService, private actionsSubject$: ActionsSubject) {
     this.timeEntriesDataSource$ = this.store.pipe(delay(0), select(getTimeEntriesDataSource));
   }
@@ -104,8 +105,20 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
       const isStartDateGreaterThanActiveEntry = startDateAsLocalDate > activeEntryAsLocalDate;
       const isEndDateGreaterThanActiveEntry = endDateAsLocalDate > activeEntryAsLocalDate;
       const isTimeEntryOverlapping = isStartDateGreaterThanActiveEntry || isEndDateGreaterThanActiveEntry;
-      if (!isEditingEntryEqualToActiveEntry && isTimeEntryOverlapping) {
-        this.toastrService.error('You are on the clock and this entry overlaps it, try with earlier times.');
+
+      if (isEditingEntryEqualToActiveEntry) {
+        this.store.pipe(select(getTimeEntriesDataSource)).subscribe(ds => {
+          const overlappingEntry = ds.data.find((item) => {
+            const itemEndDate = new Date(item.end_date);
+            return startDateAsLocalDate  < itemEndDate;
+          });
+          this.isActiveEntryOverlapping = overlappingEntry ? true : false;
+        });
+      }
+      if (!isEditingEntryEqualToActiveEntry && isTimeEntryOverlapping || this.isActiveEntryOverlapping ) {
+        const message = this.isActiveEntryOverlapping ? 'try another "Time in"' : 'try with earlier times';
+        this.toastrService.error(`You are on the clock and this entry overlaps it, ${message}.`);
+        this.isActiveEntryOverlapping = false;
       } else {
         this.doSave(event);
       }

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -105,16 +105,7 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
       const isStartDateGreaterThanActiveEntry = startDateAsLocalDate > activeEntryAsLocalDate;
       const isEndDateGreaterThanActiveEntry = endDateAsLocalDate > activeEntryAsLocalDate;
       const isTimeEntryOverlapping = isStartDateGreaterThanActiveEntry || isEndDateGreaterThanActiveEntry;
-
-      if (isEditingEntryEqualToActiveEntry) {
-        this.store.pipe(select(getTimeEntriesDataSource)).subscribe(ds => {
-          const overlappingEntry = ds.data.find((item) => {
-            const itemEndDate = new Date(item.end_date);
-            return startDateAsLocalDate  < itemEndDate;
-          });
-          this.isActiveEntryOverlapping = overlappingEntry ? true : false;
-        });
-      }
+      this.checkIfActiveEntryOverlapping(isEditingEntryEqualToActiveEntry, startDateAsLocalDate);
       if (!isEditingEntryEqualToActiveEntry && isTimeEntryOverlapping || this.isActiveEntryOverlapping ) {
         const message = this.isActiveEntryOverlapping ? 'try another "Time in"' : 'try with earlier times';
         this.toastrService.error(`You are on the clock and this entry overlaps it, ${message}.`);
@@ -182,5 +173,17 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
 
   resetDraggablePosition(event: any): void {
     event.source._dragRef.reset();
+  }
+
+  checkIfActiveEntryOverlapping(isEditingEntryEqualToActiveEntry: boolean, startDateAsLocalDate: Date) {
+    if (isEditingEntryEqualToActiveEntry) {
+      this.store.pipe(select(getTimeEntriesDataSource)).subscribe(ds => {
+        const overlappingEntry = ds.data.find((item) => {
+          const itemEndDate = new Date(item.end_date);
+          return startDateAsLocalDate  < itemEndDate;
+        });
+        this.isActiveEntryOverlapping = overlappingEntry ? true : false;
+      });
+    }
   }
 }


### PR DESCRIPTION
fix: TT-91 The time out of the penultimate time entry overlaps the time entry that is running
Added a condtion to save the entry in time-entries component and the problem is solved.