### PR TITLE
fix: TT-282 added conditions in method onSubmit and added array of activities in component project-list-hover

### DIFF
--- a/src/app/modules/time-clock/components/entry-fields/entry-fields.component.html
+++ b/src/app/modules/time-clock/components/entry-fields/entry-fields.component.html
@@ -6,8 +6,9 @@
       class="form-control"
       formControlName="activity_id"
       [class.is-invalid]="activity_id.invalid && activity_id.touched"
+      #autofocus      
       required>
-      <option *ngFor="let activity of activities" value="{{ activity.id }}">{{ activity.name }}</option>
+      <option *ngFor="let activity of activities" value="{{ activity.id }}" class = "id">{{ activity.name }}</option>
     </select>
   </div>
 

--- a/src/app/modules/time-clock/components/entry-fields/entry-fields.component.spec.ts
+++ b/src/app/modules/time-clock/components/entry-fields/entry-fields.component.spec.ts
@@ -323,10 +323,12 @@ describe('EntryFieldsComponent', () => {
   });
 
   it('dispatches an action when onSubmit is called', () => {
+    const isEntryFormValid = spyOn(component, 'entryFormIsValidate').and.returnValue(true);
     spyOn(store, 'dispatch');
 
     component.onSubmit();
 
+    expect(isEntryFormValid).toHaveBeenCalled();
     expect(store.dispatch).toHaveBeenCalled();
   });
 
@@ -553,6 +555,37 @@ describe('EntryFieldsComponent', () => {
     component.newData = mockEntry;
     featureToggleGeneralService.isActivated(FeatureToggle.UPDATE_ENTRIES).subscribe(() => {
       expect(featureToggleGeneralService.isActivated).toHaveBeenCalled();
+    });
+  });
+
+  it('when a activity is not register in DB should show activatefocus in select activity', () => {
+    const activitiesMock  = [{
+      id: 'xyz',
+      name: 'test',
+      description : 'test1'
+    }];
+    const data = {
+      activity_id: 'xyz',
+      description: '',
+      start_date: moment().format(DATE_FORMAT_YEAR),
+      start_hour: moment().format('HH:mm'),
+      uri: ''
+    };
+    component.activities = activitiesMock;
+    component.entryForm.patchValue({
+      description: data.description,
+      uri: data.uri,
+      activity_id: data.activity_id,
+      start_date: data.start_date,
+      start_hour: data.start_hour,
+    });
+    component.ngOnInit();
+    component.activateFocus();
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      const autofocus = fixture.nativeElement.querySelector('select');
+      expect(autofocus).toHaveBeenCalled();
     });
   });
 });

--- a/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.spec.ts
+++ b/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.spec.ts
@@ -39,8 +39,8 @@ describe('ProjectListHoverComponent', () => {
       isLoading: false,
       message: '',
     },
-  };
 
+  };
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
@@ -69,6 +69,12 @@ describe('ProjectListHoverComponent', () => {
 
   it('dispatchs a CreateEntry action on clockIn', () => {
     component.activeEntry = null;
+    const activitiesMock  = [{
+      id: 'xyz',
+      name: 'test',
+      description : 'test1'
+    }];
+    component.activities = activitiesMock;
     spyOn(store, 'dispatch');
 
     component.clockIn(1, 'customer', 'project');

--- a/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
+++ b/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
@@ -14,6 +14,11 @@ import {
 } from './../../../customer-management/components/projects/components/store/project.selectors';
 import { EntryActionTypes } from './../../store/entry.actions';
 import { getActiveTimeEntry } from './../../store/entry.selectors';
+import { Activity, } from '../../../shared/models';
+import { LoadActivities } from './../../../activities-management/store/activity-management.actions';
+import { allActivities } from 'src/app/modules/activities-management/store/activity-management.selectors';
+import { head } from 'lodash';
+
 @Component({
   selector: 'app-project-list-hover',
   templateUrl: './project-list-hover.component.html',
@@ -22,6 +27,7 @@ import { getActiveTimeEntry } from './../../store/entry.selectors';
 export class ProjectListHoverComponent implements OnInit, OnDestroy {
   keyword = 'search_field';
   listProjects: Project[] = [];
+  activities: Activity[] = [];
   activeEntry;
   projectsForm: FormGroup;
   showClockIn: boolean;
@@ -29,6 +35,7 @@ export class ProjectListHoverComponent implements OnInit, OnDestroy {
   isLoading$: Observable<boolean>;
   projectsSubscription: Subscription;
   activeEntrySubscription: Subscription;
+  loadActivitiesSubscription: Subscription;
 
   constructor(
     private formBuilder: FormBuilder,
@@ -51,6 +58,11 @@ export class ProjectListHoverComponent implements OnInit, OnDestroy {
         this.listProjects.push(projectWithSearchField);
       });
       this.loadActiveTimeEntry();
+    });
+    this.store.dispatch(new LoadActivities());
+    const activities$ = this.store.pipe(select(allActivities));
+    activities$.subscribe((response) => {
+      this.activities = response;
     });
     this.updateEntrySubscription = this.actionsSubject$
       .pipe(filter((action: any) => action.type === EntryActionTypes.UPDATE_ENTRY_SUCCESS))
@@ -88,6 +100,7 @@ export class ProjectListHoverComponent implements OnInit, OnDestroy {
       start_date: new Date().toISOString(),
       timezone_offset: new Date().getTimezoneOffset(),
       technologies: [],
+      activity_id: head(this.activities).id,
     };
     this.store.dispatch(new entryActions.ClockIn(entry));
     this.projectsForm.setValue({ project_id: `${customerName} - ${name}` });


### PR DESCRIPTION
### Problem
If somebody added a new time entry and if in the DB not existing register about of the information the attribute activity_id. The application can not show the information about time entry and the reports, and return: the data can not be loaded. 

### The solution
When the user selects a new project, in the panel time clock, to default send an activity_id, and the DB. 

 
