### PR TITLE
fix: TT-283 added try catch to handle method rerenderDataTable

### DIFF
--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
@@ -2,7 +2,6 @@ import { formatDate } from '@angular/common';
 import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import { select, Store } from '@ngrx/store';
 import { DataTableDirective } from 'angular-datatables';
-import * as console from 'console';
 import * as moment from 'moment';
 import { Observable, Subject } from 'rxjs';
 import { Entry } from 'src/app/modules/shared/models';

--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
@@ -2,6 +2,7 @@ import { formatDate } from '@angular/common';
 import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import { select, Store } from '@ngrx/store';
 import { DataTableDirective } from 'angular-datatables';
+import * as console from 'console';
 import * as moment from 'moment';
 import { Observable, Subject } from 'rxjs';
 import { Entry } from 'src/app/modules/shared/models';
@@ -82,11 +83,15 @@ export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewIn
   private rerenderDataTable(): void {
     if (this.dtElement && this.dtElement.dtInstance) {
       this.dtElement.dtInstance.then((dtInstance: DataTables.Api) => {
-        dtInstance.destroy();
-        this.dtTrigger.next();
+        try {
+          dtInstance.destroy();
+          this.dtTrigger.next();
+        } catch (error) {}
       });
     } else {
-      this.dtTrigger.next();
+      try {
+        this.dtTrigger.next();
+      } catch (error) {}
     }
   }
 


### PR DESCRIPTION
### Problem
Cannot read property 'clientWidth', this problem present in the section of Reports.
![](https://imgur.com/CTkBn78.png)

### Solution
Added a try-catch in the method rerenderDataTable. This method is used to handle the dimensions of the reports' table. 

