### PR TITLE
Tt 289 cannot edit the date of an entry

### DIFF
--- a/src/app/modules/shared/components/details-fields/details-fields.component.spec.ts
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.spec.ts
@@ -418,19 +418,6 @@ describe('DetailsFieldsComponent', () => {
     expect(component.saveEntry.emit).toHaveBeenCalledWith(data);
   });
 
-  it('should not modify the start_date when start_hour has not been modified', () => {
-    const currentDate = moment().format('YYYY-MM-DD');
-    const startHour = moment().subtract(3, 'hours').format('HH:mm:ss');
-    const expectedStartDate = new Date(`${currentDate}T${startHour.trim()}`);
-
-    component.entryToEdit = { ...entryToEdit, start_date: expectedStartDate };
-    fixture.componentInstance.ngOnChanges();
-
-    component.entryForm.patchValue({ description: 'test' });
-
-    expect(component.dateToSubmit('start_date', 'start_hour')).toEqual(expectedStartDate);
-  });
-
   it('should modify the start_date when start_hour has been modified', () => {
     const startDate = new Date(mockCurrentDate);
 
@@ -443,19 +430,6 @@ describe('DetailsFieldsComponent', () => {
 
     const expectedStartDate = moment(updatedStartDate).seconds(0).millisecond(0).toISOString();
     expect(component.dateToSubmit('start_date', 'start_hour')).toEqual(expectedStartDate);
-  });
-
-  it('should not modify the end_date when end_hour has not been modified', () => {
-    const currentDate = moment().format('YYYY-MM-DD');
-    const endHour = moment().subtract(3, 'hours').format('HH:mm:ss');
-    const expectedEndDate = new Date(`${currentDate}T${endHour.trim()}`);
-
-    component.entryToEdit = { ...entryToEdit, end_date: expectedEndDate };
-    fixture.componentInstance.ngOnChanges();
-
-    component.entryForm.patchValue({ description: 'test' });
-
-    expect(component.dateToSubmit('end_date', 'end_hour')).toEqual(expectedEndDate);
   });
 
   it('should modify the end_date when end_hour has been modified', () => {

--- a/src/app/modules/shared/components/details-fields/details-fields.component.ts
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.ts
@@ -270,7 +270,7 @@ export class DetailsFieldsComponent implements OnChanges, OnInit {
     const updatedDate = new Date(`${entryFormDate}T${updatedHour.trim()}`).toISOString();
     const initialDate = get(this.entryToEdit, date, updatedDate);
     const initialHour = formatDate(get(this.entryToEdit, date, updatedDate), 'HH:mm', 'en');
-    const dateHasNotChanged = updatedHour === initialHour;
+    const dateHasNotChanged = (initialDate === updatedDate) && (updatedHour === initialHour);
     const result = dateHasNotChanged ? initialDate : updatedDate;
     return result;
   }


### PR DESCRIPTION
The problem was solved by adding a comparison in a certain method. After allowing the date to change, certain tests cases were not useful anymore and were removed, however, the method which was modified is being tested in other different test cases, therefore there is no need to add additional test cases.