### PR TITLE
Tt 299 activities when active inactive an activity not display information in name description

### DIFF
--- a/src/app/modules/activities-management/store/activity-management.reducers.spec.ts
+++ b/src/app/modules/activities-management/store/activity-management.reducers.spec.ts
@@ -142,20 +142,4 @@ describe('activityManagementReducer', () => {
     expect(state.message).toEqual('Something went wrong unarchiving activities!');
     expect(state.isLoading).toBeFalse();
   });
-
-  it('on SetActivityToEdit, should save the activityId to edit', () => {
-    const action = new actions.SetActivityToEdit(activity.id);
-
-    const state = activityManagementReducer(initialState, action);
-
-    expect(state.activityIdToEdit).toEqual('1');
-  });
-
-  it('on ResetActivityToEdit, should clean the activityIdToEdit variable', () => {
-    const action = new actions.ResetActivityToEdit();
-
-    const state = activityManagementReducer(initialState, action);
-
-    expect(state.activityIdToEdit).toEqual('');
-  });
 });

--- a/src/app/modules/activities-management/store/activity-management.reducers.ts
+++ b/src/app/modules/activities-management/store/activity-management.reducers.ts
@@ -68,7 +68,6 @@ export function activityManagementReducer(state: ActivityState = initialState, a
         ...state,
         isLoading: true,
         message: 'Set activityIdToArchive property',
-        activityIdToEdit: undefined,
       };
     }
 
@@ -89,7 +88,6 @@ export function activityManagementReducer(state: ActivityState = initialState, a
         data: [],
         isLoading: false,
         message: 'Something went wrong deleting activity!',
-        activityIdToEdit: '',
       };
     }
 
@@ -127,7 +125,6 @@ export function activityManagementReducer(state: ActivityState = initialState, a
         ...state,
         isLoading: true,
         message: 'Set activityIdToUnarchive property',
-        activityIdToEdit: undefined,
       };
     }
 
@@ -140,7 +137,6 @@ export function activityManagementReducer(state: ActivityState = initialState, a
         data: activityList,
         isLoading: false,
         message: 'Unarchive activity successfully!',
-        activityIdToEdit: '',
       };
     }
 
@@ -149,7 +145,6 @@ export function activityManagementReducer(state: ActivityState = initialState, a
         ...state,
         isLoading: false,
         message: 'Something went wrong unarchiving activities!',
-        activityIdToEdit: '',
       };
     }
 

--- a/src/app/modules/activities-management/store/activity-management.reducers.ts
+++ b/src/app/modules/activities-management/store/activity-management.reducers.ts
@@ -68,7 +68,7 @@ export function activityManagementReducer(state: ActivityState = initialState, a
         ...state,
         isLoading: true,
         message: 'Set activityIdToArchive property',
-        activityIdToEdit: action.activityId,
+        activityIdToEdit: undefined,
       };
     }
 
@@ -127,7 +127,7 @@ export function activityManagementReducer(state: ActivityState = initialState, a
         ...state,
         isLoading: true,
         message: 'Set activityIdToUnarchive property',
-        activityIdToEdit: action.payload,
+        activityIdToEdit: undefined,
       };
     }
 


### PR DESCRIPTION
### Problem

In the UI, when archiving or unarchiving an activity, all the content of it was shown on the UI, as shown in the picture below. This was not visually comfortable for the user, and thus the content does not need to appear when performing the actions mentioned at the beginning.

![](https://i.postimg.cc/8PHHgmLj/activities-visual.jpg)

# Solution

The variables which were causing this visual problem were removed and therefore, the tests needed for those variables are no longer necessary and were also removed.