### PR TITLE
fix: TT-304 Handle message: the data could not be load

### DIFF
--- a/src/app/modules/time-entries/pages/time-entries.component.html
+++ b/src/app/modules/time-entries/pages/time-entries.component.html
@@ -42,7 +42,7 @@
   </ng-template>
   <ng-template #listView>
     <div id="listView">
-      <table class="table table-sm table-striped mb-0" *ngIf="timeEntriesDataSource$ | async as dataSource">
+      <table class="table table-sm table-striped mb-0" datatable [dtTrigger]="dtTrigger" [dtOptions]="dtOptions" *ngIf="timeEntriesDataSource$ | async as dataSource">
         <thead class="thead-blue">
           <tr class="d-flex">
             <th class="col">Date</th>

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -668,4 +668,11 @@ describe('TimeEntriesComponent', () => {
 
     expect(HTMLTimeEntriesView).not.toBeNull();
   });
+
+  it('after the component is initialized it should initialize the table', () => {
+    spyOn(component.dtTrigger, 'next');
+    component.ngAfterViewInit();
+
+    expect(component.dtTrigger.next).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
**Problem**
------------
In the time-entries section, when there is no data, the message _"The data could not be load"_ is displayed.
![Captura de Pantalla 2021-08-06 a la(s) 12 27 58](https://user-images.githubusercontent.com/12177501/128549763-5c532ed4-e6ab-4e7b-8d19-0e2b4a1d3379.png)

**Solution**
------------
When there is no data, the message _"The data could not be load"_ must not be displayed, instead the message _"No data available in table"_ should be displayed in the table section. That is the purpose of this pull request.
![Captura de Pantalla 2021-08-06 a la(s) 12 19 29](https://user-images.githubusercontent.com/12177501/128548457-e3a8a3dd-30c6-4659-8713-1d4ac795de11.png)
