### PR TITLE
fix: TT-310 Reports do not work with groups fixed

### DIFF
--- a/src/app/modules/users/components/users-list/users-list.component.html
+++ b/src/app/modules/users/components/users-list/users-list.component.html
@@ -1,5 +1,9 @@
 <div class="table-responsive">
-  <table *ngIf="users" class="table table-sm table-bordered table-striped mb-0" datatable [dtTrigger]="dtTrigger"
+  <table
+    *ngIf="users"
+    class="table table-sm table-bordered table-striped mb-0"
+    datatable
+    [dtTrigger]="dtTrigger"
     [dtOptions]="dtOptions">
     <thead class="thead-blue">
       <tr class="d-flex flex-wrap">
@@ -14,11 +18,14 @@
         <td class="col-4 text-break">{{ user.email }}</td>
         <td class="col-5 text-break">{{ user.name }}</td>
         <td class="col-3 text-center">
-          <ui-switch size="small"
+          <ui-switch
+            size="small"
             (change)="switchGroup('time-tracker-admin', user); updateRole(ROLES.admin, user, $event);"
             [checked]="user.groups.includes('time-tracker-admin')"></ui-switch>
           admin
-          <ui-switch size="small" (change)="switchGroup('time-tracker-tester', user)"
+          <ui-switch
+            size="small"
+            (change)="switchGroup('time-tracker-tester', user)"
             [checked]="user.groups.includes('time-tracker-tester')"></ui-switch>
           test
         </td>

--- a/src/app/modules/users/components/users-list/users-list.component.html
+++ b/src/app/modules/users/components/users-list/users-list.component.html
@@ -14,7 +14,8 @@
         <td class="col-4 text-break">{{ user.email }}</td>
         <td class="col-5 text-break">{{ user.name }}</td>
         <td class="col-3 text-center">
-          <ui-switch size="small" (change)="switchGroup('time-tracker-admin', user); updateRole(ROLES.admin, user);"
+          <ui-switch size="small"
+            (change)="switchGroup('time-tracker-admin', user); updateRole(ROLES.admin, user, $event);"
             [checked]="user.groups.includes('time-tracker-admin')"></ui-switch>
           admin
           <ui-switch size="small" (change)="switchGroup('time-tracker-tester', user)"

--- a/src/app/modules/users/components/users-list/users-list.component.html
+++ b/src/app/modules/users/components/users-list/users-list.component.html
@@ -1,11 +1,6 @@
 <div class="table-responsive">
-  <table
-    *ngIf="users"
-    class="table table-sm table-bordered table-striped mb-0"
-    datatable
-    [dtTrigger]="dtTrigger"
-    [dtOptions]="dtOptions"
-  >
+  <table *ngIf="users" class="table table-sm table-bordered table-striped mb-0" datatable [dtTrigger]="dtTrigger"
+    [dtOptions]="dtOptions">
     <thead class="thead-blue">
       <tr class="d-flex flex-wrap">
         <th class="col-4">User Email</th>
@@ -19,17 +14,11 @@
         <td class="col-4 text-break">{{ user.email }}</td>
         <td class="col-5 text-break">{{ user.name }}</td>
         <td class="col-3 text-center">
-          <ui-switch
-            size="small"
-            (change)="switchGroup('time-tracker-admin', user)"
-            [checked]="user.groups.includes('time-tracker-admin')"
-          ></ui-switch>
+          <ui-switch size="small" (change)="switchGroup('time-tracker-admin', user); updateRole(ROLES.admin, user);"
+            [checked]="user.groups.includes('time-tracker-admin')"></ui-switch>
           admin
-          <ui-switch
-            size="small"
-            (change)="switchGroup('time-tracker-tester', user)"
-            [checked]="user.groups.includes('time-tracker-tester')"
-          ></ui-switch>
+          <ui-switch size="small" (change)="switchGroup('time-tracker-tester', user)"
+            [checked]="user.groups.includes('time-tracker-tester')"></ui-switch>
           test
         </td>
       </tr>

--- a/src/app/modules/users/components/users-list/users-list.component.spec.ts
+++ b/src/app/modules/users/components/users-list/users-list.component.spec.ts
@@ -168,7 +168,7 @@ describe('UsersListComponent', () => {
     expect(component.dtElement.dtInstance.then).toHaveBeenCalled();
   });
 
-  it('When the user does not have the role, this role must be added', () => {
+  it('When the toggle is enabled, the role must be added to the user ', () => {
     const availableRoles = [
       {
         name: 'admin',
@@ -190,12 +190,13 @@ describe('UsersListComponent', () => {
     };
 
     availableRoles.forEach((role) => {
-      component.updateRole(role, user);
+      const isToggleEnabled = true;
+      component.updateRole(role, user, isToggleEnabled);
       expect(store.dispatch).toHaveBeenCalledWith(new GrantUserRole(user.id, role.name));
     });
   });
 
-  it('When the user has the role, this role must be removed', () => {
+  it('When the toggle is disabled, the role must be removed from the user', () => {
     const availableRoles = [
       {
         name: 'admin',
@@ -217,7 +218,8 @@ describe('UsersListComponent', () => {
     };
 
     availableRoles.forEach((role) => {
-      component.updateRole(role, user);
+      const isToggleEnabled = false;
+      component.updateRole(role, user, isToggleEnabled);
       expect(store.dispatch).toHaveBeenCalledWith(new RevokeUserRole(user.id, role.name));
     });
   });

--- a/src/app/modules/users/components/users-list/users-list.component.spec.ts
+++ b/src/app/modules/users/components/users-list/users-list.component.spec.ts
@@ -6,6 +6,7 @@ import { UserActionTypes, UserState, LoadUsers, AddUserToGroup, RemoveUserFromGr
 import { ActionsSubject } from '@ngrx/store';
 import { DataTablesModule } from 'angular-datatables';
 import { GrantUserRole, RevokeUserRole } from '../../store/user.actions';
+import { ROLES } from '../../../../../environments/environment';
 
 describe('UsersListComponent', () => {
   let component: UsersListComponent;
@@ -222,6 +223,10 @@ describe('UsersListComponent', () => {
       component.updateRole(role, user, isToggleEnabled);
       expect(store.dispatch).toHaveBeenCalledWith(new RevokeUserRole(user.id, role.name));
     });
+  });
+
+  it('When we call ROLES variable should return available roles', () => {
+    expect(component.ROLES).toEqual(ROLES);
   });
 
   afterEach(() => {

--- a/src/app/modules/users/components/users-list/users-list.component.ts
+++ b/src/app/modules/users/components/users-list/users-list.component.ts
@@ -1,16 +1,14 @@
+import { GrantUserRole } from './../../store/user.actions';
 import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActionsSubject, select, Store, Action } from '@ngrx/store';
 import { DataTableDirective } from 'angular-datatables';
 import { Observable, Subject, Subscription } from 'rxjs';
 import { delay, filter } from 'rxjs/operators';
+import { ROLES } from 'src/environments/environment';
 import { User } from '../../models/users';
-import {
-  LoadUsers,
-  UserActionTypes,
-  AddUserToGroup,
-  RemoveUserFromGroup,
-} from '../../store/user.actions';
+import { LoadUsers, UserActionTypes, AddUserToGroup, RemoveUserFromGroup } from '../../store/user.actions';
 import { getIsLoading } from '../../store/user.selectors';
+import { RevokeUserRole } from '../../store/user.actions';
 
 @Component({
   selector: 'app-users-list',
@@ -28,10 +26,11 @@ export class UsersListComponent implements OnInit, OnDestroy, AfterViewInit {
   dtOptions: any = {};
   switchGroupsSubscription: Subscription;
 
-  constructor(
-    private store: Store<User>,
-    private actionsSubject$: ActionsSubject,
-  ) {
+  public get ROLES() {
+    return ROLES;
+  }
+
+  constructor(private store: Store<User>, private actionsSubject$: ActionsSubject) {
     this.isLoading$ = store.pipe(delay(0), select(getIsLoading));
   }
 
@@ -75,6 +74,13 @@ export class UsersListComponent implements OnInit, OnDestroy, AfterViewInit {
         ? new RemoveUserFromGroup(user.id, groupName)
         : new AddUserToGroup(user.id, groupName)
     );
+  }
+
+  updateRole(role: { name: string; value: string }, user: User) {
+    const userHasRole = user.roles.includes(role.value);
+    const action = userHasRole ? new RevokeUserRole(user.id, role.name) : new GrantUserRole(user.id, role.name);
+
+    this.store.dispatch(action);
   }
 
   filterUserGroup(): Observable<Action> {

--- a/src/app/modules/users/components/users-list/users-list.component.ts
+++ b/src/app/modules/users/components/users-list/users-list.component.ts
@@ -1,4 +1,4 @@
-import { GrantUserRole } from './../../store/user.actions';
+import { GrantUserRole, RevokeUserRole } from './../../store/user.actions';
 import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActionsSubject, select, Store, Action } from '@ngrx/store';
 import { DataTableDirective } from 'angular-datatables';
@@ -8,7 +8,6 @@ import { ROLES } from 'src/environments/environment';
 import { User } from '../../models/users';
 import { LoadUsers, UserActionTypes, AddUserToGroup, RemoveUserFromGroup } from '../../store/user.actions';
 import { getIsLoading } from '../../store/user.selectors';
-import { RevokeUserRole } from '../../store/user.actions';
 
 @Component({
   selector: 'app-users-list',

--- a/src/app/modules/users/components/users-list/users-list.component.ts
+++ b/src/app/modules/users/components/users-list/users-list.component.ts
@@ -75,10 +75,8 @@ export class UsersListComponent implements OnInit, OnDestroy, AfterViewInit {
     );
   }
 
-  updateRole(role: { name: string; value: string }, user: User) {
-    const userHasRole = user.roles.includes(role.value);
-    const action = userHasRole ? new RevokeUserRole(user.id, role.name) : new GrantUserRole(user.id, role.name);
-
+  updateRole(role: { name: string; value: string }, user: User, isToggleEnabled: boolean) {
+    const action = isToggleEnabled ? new GrantUserRole(user.id, role.name) : new RevokeUserRole(user.id, role.name);
     this.store.dispatch(action);
   }
 

--- a/src/app/modules/users/store/user.actions.spec.ts
+++ b/src/app/modules/users/store/user.actions.spec.ts
@@ -58,4 +58,46 @@ describe('UserActions', () => {
 
     expect(action.type).toEqual(actions.UserActionTypes.REMOVE_USER_FROM_GROUP_FAIL);
   });
+
+  it('GrantUserRole type is UserActionTypes.GRANT_USER_ROLE', () => {
+    const userId = 'no-matter-id';
+    const roleId = 'no-matter-role-id';
+    const action = new actions.GrantUserRole(userId, roleId);
+
+    expect(action.type).toEqual(actions.UserActionTypes.GRANT_USER_ROLE);
+  });
+
+  it('GrantUserRoleSuccess type is UserActionTypes.GRANT_USER_ROLE_SUCCESS', () => {
+    const user: User = { id: 'id', email: 'email', name: 'name' };
+    const action = new actions.GrantUserRoleSuccess(user);
+
+    expect(action.type).toEqual(actions.UserActionTypes.GRANT_USER_ROLE_SUCCESS);
+  });
+
+  it('GrantUserRoleFail type is UserActionTypes.GRANT_USER_ROLE_FAIL', () => {
+    const action = new actions.GrantUserRoleFail('error');
+
+    expect(action.type).toEqual(actions.UserActionTypes.GRANT_USER_ROLE_FAIL);
+  });
+
+  it('RevokeUserRole type is UserActionTypes.REVOKE_USER_ROLE', () => {
+    const userId = 'no-matter-id';
+    const roleId = 'no-matter-role-id';
+    const action = new actions.RevokeUserRole(userId, roleId);
+
+    expect(action.type).toEqual(actions.UserActionTypes.REVOKE_USER_ROLE);
+  });
+
+  it('RevokeUserRoleSuccess type is UserActionTypes.REVOKE_USER_ROLE_SUCCESS', () => {
+    const user: User = { id: 'id', email: 'email', name: 'name' };
+    const action = new actions.RevokeUserRoleSuccess(user);
+
+    expect(action.type).toEqual(actions.UserActionTypes.REVOKE_USER_ROLE_SUCCESS);
+  });
+
+  it('RevokeUserRoleFail type is UserActionTypes.REVOKE_USER_ROLE_FAIL', () => {
+    const action = new actions.RevokeUserRoleFail('error');
+
+    expect(action.type).toEqual(actions.UserActionTypes.REVOKE_USER_ROLE_FAIL);
+  });
 });

--- a/src/app/modules/users/store/user.actions.ts
+++ b/src/app/modules/users/store/user.actions.ts
@@ -11,7 +11,13 @@ export enum UserActionTypes {
   REMOVE_USER_FROM_GROUP = '[User] REMOVE_USER_FROM_GROUP',
   REMOVE_USER_FROM_GROUP_SUCCESS = '[User] REMOVE_USER_FROM_GROUP_SUCCESS',
   REMOVE_USER_FROM_GROUP_FAIL = '[User] REMOVE_USER_FROM_GROUP_FAIL',
-  DEFAULT_USER = '[USER] DEFAULT_USER',
+  GRANT_USER_ROLE = '[User] GRANT_USER_ROLE',
+  GRANT_USER_ROLE_SUCCESS = '[User] GRANT_USER_ROLE_SUCCESS',
+  GRANT_USER_ROLE_FAIL = '[User] GRANT_USER_ROLE_FAIL',
+  REVOKE_USER_ROLE = '[User] REVOKE_USER_ROLE',
+  REVOKE_USER_ROLE_SUCCESS = '[User] REVOKE_USER_ROLE_SUCCESS',
+  REVOKE_USER_ROLE_FAIL = '[User] REVOKE_USER_ROLE_FAIL',
+  DEFAULT_USER = '[User] DEFAULT_USER',
 }
 
 export class LoadUsers implements Action {
@@ -20,42 +26,72 @@ export class LoadUsers implements Action {
 
 export class LoadUsersSuccess implements Action {
   readonly type = UserActionTypes.LOAD_USERS_SUCCESS;
-  constructor(readonly payload: User[]) { }
+  constructor(readonly payload: User[]) {}
 }
 
 export class LoadUsersFail implements Action {
   public readonly type = UserActionTypes.LOAD_USERS_FAIL;
-  constructor(public error: string) { }
+  constructor(public error: string) {}
 }
 
 export class AddUserToGroup implements Action {
   public readonly type = UserActionTypes.ADD_USER_TO_GROUP;
-  constructor(public userId: string, public groupName: string) { }
+  constructor(public userId: string, public groupName: string) {}
 }
 
 export class AddUserToGroupSuccess implements Action {
   public readonly type = UserActionTypes.ADD_USER_TO_GROUP_SUCCESS;
-  constructor(readonly payload: User) { }
+  constructor(readonly payload: User) {}
 }
 
 export class AddUserToGroupFail implements Action {
   public readonly type = UserActionTypes.ADD_USER_TO_GROUP_FAIL;
-  constructor(public error: string) { }
+  constructor(public error: string) {}
 }
 
 export class RemoveUserFromGroup implements Action {
   public readonly type = UserActionTypes.REMOVE_USER_FROM_GROUP;
-  constructor(public userId: string, public groupName: string) { }
+  constructor(public userId: string, public groupName: string) {}
 }
 
 export class RemoveUserFromGroupSuccess implements Action {
   public readonly type = UserActionTypes.REMOVE_USER_FROM_GROUP_SUCCESS;
-  constructor(readonly payload: User) { }
+  constructor(readonly payload: User) {}
 }
 
 export class RemoveUserFromGroupFail implements Action {
   public readonly type = UserActionTypes.REMOVE_USER_FROM_GROUP_FAIL;
-  constructor(public error: string) { }
+  constructor(public error: string) {}
+}
+
+export class GrantUserRole implements Action {
+  public readonly type = UserActionTypes.GRANT_USER_ROLE;
+  constructor(public userId: string, public roleId: string) {}
+}
+
+export class GrantUserRoleSuccess implements Action {
+  public readonly type = UserActionTypes.GRANT_USER_ROLE_SUCCESS;
+  constructor(readonly payload: User) {}
+}
+
+export class GrantUserRoleFail implements Action {
+  public readonly type = UserActionTypes.GRANT_USER_ROLE_FAIL;
+  constructor(public error: string) {}
+}
+
+export class RevokeUserRole implements Action {
+  public readonly type = UserActionTypes.REVOKE_USER_ROLE;
+  constructor(public userId: string, public roleId: string) {}
+}
+
+export class RevokeUserRoleSuccess implements Action {
+  public readonly type = UserActionTypes.REVOKE_USER_ROLE_SUCCESS;
+  constructor(readonly payload: User) {}
+}
+
+export class RevokeUserRoleFail implements Action {
+  public readonly type = UserActionTypes.REVOKE_USER_ROLE_FAIL;
+  constructor(public error: string) {}
 }
 
 export class DefaultUser implements Action {
@@ -72,4 +108,10 @@ export type UserActions =
   | AddUserToGroupFail
   | RemoveUserFromGroup
   | RemoveUserFromGroupSuccess
-  | RemoveUserFromGroupFail;
+  | RemoveUserFromGroupFail
+  | GrantUserRole
+  | GrantUserRoleSuccess
+  | GrantUserRoleFail
+  | RevokeUserRole
+  | RevokeUserRoleSuccess
+  | RevokeUserRoleFail;

--- a/src/app/modules/users/store/user.effects.spec.ts
+++ b/src/app/modules/users/store/user.effects.spec.ts
@@ -3,7 +3,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { Observable, of, throwError } from 'rxjs';
 import { UsersService } from '../services/users.service';
-import { UserActionTypes } from './user.actions';
+import { UserActionTypes, RevokeUserRoleFail } from './user.actions';
 import { UserEffects } from './user.effects';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ToastrModule, ToastrService } from 'ngx-toastr';
@@ -121,6 +121,82 @@ describe('UserEffects', () => {
     effects.removeUserFromGroup$.subscribe((action) => {
       expect(toastrService.error).toHaveBeenCalled();
       expect(action.type).toEqual(UserActionTypes.REMOVE_USER_FROM_GROUP_FAIL);
+    });
+  });
+
+  it('action type should be GRANT_USER_ROLE_SUCCESS when grantUserRole effect was executed successfully', async () => {
+    const userId = 'userId';
+    const roleId = 'admin';
+
+    actions$ = of({
+      type: UserActionTypes.GRANT_USER_ROLE,
+      userId,
+      roleId,
+    });
+
+    spyOn(toastrService, 'success');
+    spyOn(service, 'grantRole').and.returnValue(of(user));
+
+    effects.grantUserRole$.subscribe((action) => {
+      expect(toastrService.success).toHaveBeenCalledWith('User role successfully granted');
+      expect(action.type).toEqual(UserActionTypes.GRANT_USER_ROLE_SUCCESS);
+    });
+  });
+
+  it('action type should be GRANT_USER_ROLE_FAIL when grantUserRole effect failed', async () => {
+    const userId = 'userId';
+    const roleId = 'admin';
+
+    actions$ = of({
+      type: UserActionTypes.GRANT_USER_ROLE,
+      userId,
+      roleId,
+    });
+
+    spyOn(toastrService, 'error');
+    spyOn(service, 'grantRole').and.returnValue(throwError({ error: { message: 'error' } }));
+
+    effects.grantUserRole$.subscribe((action) => {
+      expect(toastrService.error).toHaveBeenCalled();
+      expect(action.type).toEqual(UserActionTypes.GRANT_USER_ROLE_FAIL);
+    });
+  });
+
+  it('action type should be REVOKE_USER_SUCCESS when revokeUserRole effect was executed successfully', async () => {
+    const userId = 'userId';
+    const roleId = 'admin';
+
+    actions$ = of({
+      type: UserActionTypes.REVOKE_USER_ROLE,
+      userId,
+      roleId,
+    });
+
+    spyOn(toastrService, 'success');
+    spyOn(service, 'revokeRole').and.returnValue(throwError({ error: { message: 'error' } }));
+
+    effects.grantUserRole$.subscribe((action) => {
+      expect(toastrService.success).toHaveBeenCalledWith('User role successfully revoked');
+      expect(action.type).toEqual(UserActionTypes.REVOKE_USER_ROLE_SUCCESS);
+    });
+  });
+
+  it('action type should be REVOKE_USER_FAIL when revokeUserRole effect failed', async () => {
+    const userId = 'userId';
+    const roleId = 'admin';
+
+    actions$ = of({
+      type: UserActionTypes.REVOKE_USER_ROLE,
+      userId,
+      roleId,
+    });
+
+    spyOn(toastrService, 'error');
+    spyOn(service, 'revokeRole').and.returnValue(throwError({ error: { message: 'error' } }));
+
+    effects.grantUserRole$.subscribe((action) => {
+      expect(toastrService.error).toHaveBeenCalled();
+      expect(action.type).toEqual(UserActionTypes.REVOKE_USER_ROLE_FAIL);
     });
   });
 });

--- a/src/app/modules/users/store/user.effects.spec.ts
+++ b/src/app/modules/users/store/user.effects.spec.ts
@@ -3,7 +3,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Action } from '@ngrx/store';
 import { Observable, of, throwError } from 'rxjs';
 import { UsersService } from '../services/users.service';
-import { UserActionTypes, RevokeUserRoleFail } from './user.actions';
+import { UserActionTypes } from './user.actions';
 import { UserEffects } from './user.effects';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ToastrModule, ToastrService } from 'ngx-toastr';

--- a/src/app/modules/users/store/user.effects.spec.ts
+++ b/src/app/modules/users/store/user.effects.spec.ts
@@ -173,9 +173,9 @@ describe('UserEffects', () => {
     });
 
     spyOn(toastrService, 'success');
-    spyOn(service, 'revokeRole').and.returnValue(throwError({ error: { message: 'error' } }));
+    spyOn(service, 'revokeRole').and.returnValue(of(user));
 
-    effects.grantUserRole$.subscribe((action) => {
+    effects.revokeUserRole$.subscribe((action) => {
       expect(toastrService.success).toHaveBeenCalledWith('User role successfully revoked');
       expect(action.type).toEqual(UserActionTypes.REVOKE_USER_ROLE_SUCCESS);
     });
@@ -194,7 +194,7 @@ describe('UserEffects', () => {
     spyOn(toastrService, 'error');
     spyOn(service, 'revokeRole').and.returnValue(throwError({ error: { message: 'error' } }));
 
-    effects.grantUserRole$.subscribe((action) => {
+    effects.revokeUserRole$.subscribe((action) => {
       expect(toastrService.error).toHaveBeenCalled();
       expect(action.type).toEqual(UserActionTypes.REVOKE_USER_ROLE_FAIL);
     });

--- a/src/app/modules/users/store/user.effects.ts
+++ b/src/app/modules/users/store/user.effects.ts
@@ -10,7 +10,7 @@ import * as actions from './user.actions';
 
 @Injectable()
 export class UserEffects {
-  constructor(private actions$: Actions, private userService: UsersService, private toastrService: ToastrService) { }
+  constructor(private actions$: Actions, private userService: UsersService, private toastrService: ToastrService) {}
 
   @Effect()
   loadUsers$: Observable<Action> = this.actions$.pipe(
@@ -59,6 +59,42 @@ export class UserEffects {
         catchError((error) => {
           this.toastrService.error(error.error.message);
           return of(new actions.RemoveUserFromGroupFail(error));
+        })
+      )
+    )
+  );
+
+  @Effect()
+  grantUserRole$: Observable<Action> = this.actions$.pipe(
+    ofType(actions.UserActionTypes.GRANT_USER_ROLE),
+    map((action: actions.GrantUserRole) => action),
+    mergeMap((action) =>
+      this.userService.grantRole(action.userId, action.roleId).pipe(
+        map((response) => {
+          this.toastrService.success('User role successfully granted');
+          return new actions.GrantUserRoleSuccess(response);
+        }),
+        catchError((error) => {
+          this.toastrService.error(error.error.message);
+          return of(new actions.GrantUserRoleFail(error));
+        })
+      )
+    )
+  );
+
+  @Effect()
+  revokeUserRole$: Observable<Action> = this.actions$.pipe(
+    ofType(actions.UserActionTypes.REVOKE_USER_ROLE),
+    map((action: actions.RevokeUserRole) => action),
+    mergeMap((action) =>
+      this.userService.revokeRole(action.userId, action.roleId).pipe(
+        map((response) => {
+          this.toastrService.success('User role successfully revoked');
+          return new actions.RevokeUserRoleSuccess(response);
+        }),
+        catchError((error) => {
+          this.toastrService.error(error.error.message);
+          return of(new actions.RevokeUserRoleFail(error));
         })
       )
     )

--- a/src/app/modules/users/store/user.reducers.spec.ts
+++ b/src/app/modules/users/store/user.reducers.spec.ts
@@ -93,6 +93,100 @@ describe('userReducer', () => {
     expect(state.isLoading).toEqual(false);
   });
 
+  it('on GrantUserRole, isLoading should be true', () => {
+    const userId = 'no-matter-id';
+    const roleId = 'no-maatter-role-id';
+    const action = new actions.GrantUserRole(userId, roleId);
+
+    const state = userReducer(initialState, action);
+
+    expect(state.isLoading).toBeTrue();
+  });
+
+  it('on GrantUserRoleSuccess, state should be updated', () => {
+    const currentState: UserState = {
+      data: [
+        {
+          id: '1',
+          name: 'no-matter-name',
+          email: 'no-matter-email',
+          roles: [],
+        },
+      ],
+      isLoading: false,
+      message: '',
+    };
+
+    const userWithRoleAdded: User = {
+      id: '1',
+      name: 'no-matter-name',
+      email: 'no-matter-email',
+      roles: ['time-tracker-admin'],
+    };
+
+    const action = new actions.GrantUserRoleSuccess(userWithRoleAdded);
+    const state = userReducer(currentState, action);
+
+    expect(state.isLoading).toBeFalse();
+    expect(state.message).toBe('User role successfully granted');
+    expect(state.data).toEqual([userWithRoleAdded]);
+  });
+
+  it('on GrantUserRoleFail, state should not be updated', () => {
+    const action = new actions.GrantUserRoleFail('error');
+    const state = userReducer(initialState, action);
+
+    expect(state.isLoading).toBeFalse();
+    expect(state.message).toBe('Something went wrong granting access role to the user');
+  });
+
+  it('on RevokeUserRole, state should be updated', () => {
+    const userId = 'no-matter-id';
+    const roleId = 'no-maatter-role-id';
+    const action = new actions.RevokeUserRole(userId, roleId);
+
+    const state = userReducer(initialState, action);
+
+    expect(state.isLoading).toBeTrue();
+  });
+
+  it('on RevokeUserRoleSuccess, state data should be updated', () => {
+    const currentState: UserState = {
+      data: [
+        {
+          id: '1',
+          name: 'no-matter-name',
+          email: 'no-matter-email',
+          roles: ['time-tracker-admin'],
+        },
+      ],
+      isLoading: false,
+      message: '',
+    };
+
+    const user: User = {
+      id: '1',
+      name: 'no-matter-name',
+      email: 'no-matter-email',
+      roles: [],
+    };
+
+    const action = new actions.RevokeUserRoleSuccess(user);
+    const state = userReducer(currentState, action);
+
+    expect(state.isLoading).toBeFalse();
+    expect(state.message).toBe('User role successfully revoked');
+    expect(state.data).toEqual([user]);
+  });
+
+  it('on RevokeUserRoleFail, state should not be updated', () => {
+    const action = new actions.RevokeUserRoleFail('error');
+    const state = userReducer(initialState, action);
+
+    expect(state.isLoading).toBeFalse();
+    expect(state.message).toBe('Something went wrong revoking access role to the user');
+  });
+
   it('on Default, ', () => {
     const action = new actions.DefaultUser();
     const state = userReducer(initialState, action);

--- a/src/app/modules/users/store/user.reducers.ts
+++ b/src/app/modules/users/store/user.reducers.ts
@@ -82,6 +82,55 @@ export const userReducer = (state: UserState = initialState, action: UserActions
         message: 'Something went wrong removing user from group',
       };
     }
+    case UserActionTypes.GRANT_USER_ROLE: {
+      return {
+        ...state,
+        isLoading: true,
+      };
+    }
+
+    case UserActionTypes.GRANT_USER_ROLE_SUCCESS: {
+      const index = userData.findIndex((user) => user.id === action.payload.id);
+      userData[index] = action.payload;
+      return {
+        data: userData,
+        isLoading: false,
+        message: 'User role successfully granted',
+      };
+    }
+
+    case UserActionTypes.GRANT_USER_ROLE_FAIL: {
+      return {
+        ...state,
+        isLoading: false,
+        message: 'Something went wrong granting access role to the user',
+      };
+    }
+
+    case UserActionTypes.REVOKE_USER_ROLE: {
+      return {
+        ...state,
+        isLoading: true,
+      };
+    }
+
+    case UserActionTypes.REVOKE_USER_ROLE_SUCCESS: {
+      const index = userData.findIndex((user) => user.id === action.payload.id);
+      userData[index] = action.payload;
+      return {
+        data: userData,
+        isLoading: false,
+        message: 'User role successfully revoked',
+      };
+    }
+
+    case UserActionTypes.REVOKE_USER_ROLE_FAIL: {
+      return {
+        ...state,
+        isLoading: false,
+        message: 'Something went wrong revoking access role to the user',
+      };
+    }
     default:
       return state;
   }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -23,6 +23,16 @@ export const GROUPS = {
   TESTER: 'time-tracker-tester',
 };
 
+export const ROLES = {
+  admin: {
+    name: 'admin',
+    value: 'time-tracker-admin',
+  },
+  tester: {
+    name: 'test',
+    value: 'time-tracker-tester',
+  },
+};
 /*
  * For easier debugging in development mode, you can import the following file
  * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.


### PR DESCRIPTION
## Description
Currently, the backend verifies the user has the `admin` role to visualize information in the reports section.
However, the Time Tracker UI, in the Users section, only adds the user to the group of `time-tracker-admin` but does not add the role.
## Solution
With this PR each time a user is added to the admin group, the admin role is also added, and if the user is removed, the admin role is removed as well.