### PR TITLE
fix: TT-311 Can not update entries fixed

### DIFF
--- a/src/app/modules/shared/components/details-fields/details-fields.component.spec.ts
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.spec.ts
@@ -660,13 +660,13 @@ describe('DetailsFieldsComponent', () => {
         date: '2021-04-20',
         hourAndMinutes: '10:00',
         seconds: 20,
-        miliseconds: 10,
+        miliseconds: 100,
       },
       {
         date: '2020-09-21',
         hourAndMinutes: '08:00',
         seconds: 10,
-        miliseconds: 10,
+        miliseconds: 100,
       },
       {
         date: '2021-04-15',
@@ -678,15 +678,15 @@ describe('DetailsFieldsComponent', () => {
         date: '2019-03-29',
         hourAndMinutes: '12:00',
         seconds: 30,
-        miliseconds: 40,
+        miliseconds: 400,
       },
     ];
 
     const expectedISODates = [
-      '2021-04-20T15:00:20.100Z',
-      '2020-09-21T13:00:10.100Z',
-      '2021-04-16T04:00:00.000Z',
-      '2019-03-29T17:00:30.400Z',
+      new Date('2021-04-20T10:00:20.100').toISOString(),
+      new Date('2020-09-21T08:00:10.100').toISOString(),
+      new Date('2021-04-15T23:00:00.000').toISOString(),
+      new Date('2019-03-29T12:00:30.400').toISOString(),
     ];
 
     fakeDates.forEach(({ date, hourAndMinutes, seconds, miliseconds }, fakeDateIndex) => {

--- a/src/app/modules/shared/components/details-fields/details-fields.component.spec.ts
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.spec.ts
@@ -701,7 +701,7 @@ describe('DetailsFieldsComponent', () => {
     const expectedISOFormatNumbers = ['01', '02', '03', '04', '20', '30', '40', '32', '45'];
 
     numbersForTest.forEach((currentNumber, numberIndex) => {
-      const numberinISOFormat = component.getNumberInISOFornat(currentNumber);
+      const numberinISOFormat = component.getNumberInISOFormat(currentNumber);
       expect(numberinISOFormat).toBe(expectedISOFormatNumbers[numberIndex]);
     });
   });

--- a/src/app/modules/shared/components/details-fields/details-fields.component.spec.ts
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.spec.ts
@@ -141,8 +141,8 @@ describe('DetailsFieldsComponent', () => {
       uri: 'ticketUri',
       start_date: '',
       end_date: '',
-      start_hour: '00:00:10',
-      end_hour: '00:00:11',
+      start_hour: '00:00',
+      end_hour: '00:00',
       description: '',
       technology: '',
     };
@@ -176,22 +176,23 @@ describe('DetailsFieldsComponent', () => {
     expect(component.saveEntry.emit).toHaveBeenCalledTimes(0);
   });
 
-  [{ actionType: EntryActionTypes.CREATE_ENTRY_SUCCESS }, { actionType: EntryActionTypes.UPDATE_ENTRY_SUCCESS }].forEach(
-    (param) => {
-      it(`cleanForm after an action type ${param.actionType} is received`, () => {
-        const actionSubject = TestBed.inject(ActionsSubject) as ActionsSubject;
-        const action = {
-          type: param.actionType,
-        };
-        spyOn(component, 'cleanForm');
+  [
+    { actionType: EntryActionTypes.CREATE_ENTRY_SUCCESS },
+    { actionType: EntryActionTypes.UPDATE_ENTRY_SUCCESS },
+  ].forEach((param) => {
+    it(`cleanForm after an action type ${param.actionType} is received`, () => {
+      const actionSubject = TestBed.inject(ActionsSubject) as ActionsSubject;
+      const action = {
+        type: param.actionType,
+      };
+      spyOn(component, 'cleanForm');
 
-        component.ngOnInit();
-        actionSubject.next(action);
+      component.ngOnInit();
+      actionSubject.next(action);
 
-        expect(component.cleanForm).toHaveBeenCalled();
-      });
-    }
-  );
+      expect(component.cleanForm).toHaveBeenCalled();
+    });
+  });
 
   it('on cleanFieldsForm the project_id and project_name should be kept', () => {
     const entryFormValueExpected = {
@@ -295,8 +296,8 @@ describe('DetailsFieldsComponent', () => {
       uri: '',
       start_date: '2020-02-05',
       end_date: '2020-02-05',
-      start_hour: '00:00:01',
-      end_hour: '00:01:01',
+      start_hour: '00:00',
+      end_hour: '00:01',
       description: '',
       technology: '',
     });
@@ -309,8 +310,8 @@ describe('DetailsFieldsComponent', () => {
         activity_id: 'a1',
         technologies: [],
         description: '',
-        start_date: new Date('2020-02-05T00:00:01').toISOString(),
-        end_date: new Date('2020-02-05T00:01:01').toISOString(),
+        start_date: new Date('2020-02-05T00:00:00').toISOString(),
+        end_date: new Date('2020-02-05T00:01:00').toISOString(),
         uri: '',
         timezone_offset: new Date().getTimezoneOffset(),
       },
@@ -408,7 +409,7 @@ describe('DetailsFieldsComponent', () => {
         activity_id: 'a1',
         technologies: [],
         description: '',
-        start_date: new Date('2020-06-11T00:00:10').toISOString(),
+        start_date: new Date('2020-06-11T00:00:00').toISOString(),
         uri: 'ticketUri',
         timezone_offset: new Date().getTimezoneOffset(),
       },
@@ -651,6 +652,58 @@ describe('DetailsFieldsComponent', () => {
     componentToTest.entryForm.setValue({ ...formValues, ...times });
     componentToTest.onSubmit();
     expect(toastrServiceStub.error).not.toHaveBeenCalled();
+  });
+
+  it('Should return a date in ISO format given a date, hour, minute, second and milisecond', () => {
+    const fakeDates = [
+      {
+        date: '2021-04-20',
+        hourAndMinutes: '10:00',
+        seconds: 20,
+        miliseconds: 10,
+      },
+      {
+        date: '2020-09-21',
+        hourAndMinutes: '08:00',
+        seconds: 10,
+        miliseconds: 10,
+      },
+      {
+        date: '2021-04-15',
+        hourAndMinutes: '23:00',
+        seconds: 0,
+        miliseconds: 0,
+      },
+      {
+        date: '2019-03-29',
+        hourAndMinutes: '12:00',
+        seconds: 30,
+        miliseconds: 40,
+      },
+    ];
+
+    const expectedISODates = [
+      '2021-04-20T15:00:20.100Z',
+      '2020-09-21T13:00:10.100Z',
+      '2021-04-16T04:00:00.000Z',
+      '2019-03-29T17:00:30.400Z',
+    ];
+
+    fakeDates.forEach(({ date, hourAndMinutes, seconds, miliseconds }, fakeDateIndex) => {
+      const dateInISOFormat = component.getDateISOFormat(date, hourAndMinutes, seconds, miliseconds);
+      expect(dateInISOFormat).toBe(expectedISODates[fakeDateIndex]);
+    });
+  });
+
+  it('should return a number in ISO format given a normal number', () => {
+    const numbersForTest = [1, 2, 3, 4, 20, 30, 40, 32, 45];
+
+    const expectedISOFormatNumbers = ['01', '02', '03', '04', '20', '30', '40', '32', '45'];
+
+    numbersForTest.forEach((currentNumber, numberIndex) => {
+      const numberinISOFormat = component.getNumberInISOFornat(currentNumber);
+      expect(numberinISOFormat).toBe(expectedISOFormatNumbers[numberIndex]);
+    });
   });
   /*
    TODO As part of https://github.com/ioet/time-tracker-ui/issues/424 a new parameter was added to the details-field-component,

--- a/src/app/modules/shared/components/details-fields/details-fields.component.ts
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.ts
@@ -264,12 +264,39 @@ export class DetailsFieldsComponent implements OnChanges, OnInit {
     return startDate >= endDate;
   }
 
-  dateToSubmit(date, hour) {
-    const entryFormDate = this.entryForm.value[date];
-    const updatedHour = this.entryForm.value[hour];
-    const updatedDate = new Date(`${entryFormDate}T${updatedHour.trim()}`).toISOString();
+  getDateISOFormat(date: string, hourAndMinutes: string, seconds, miliseconds: number): string {
+    hourAndMinutes = hourAndMinutes.trim();
+    const secondsInISOFormat: string = this.getNumberInISOFornat(seconds);
+    const milisecondsInISOFormat: string = this.getNumberInISOFornat(miliseconds);
+    const ISOFormat = `${date}T${hourAndMinutes}:${secondsInISOFormat}.${milisecondsInISOFormat}`;
+    const dateISOFormat: string = new Date(ISOFormat).toISOString();
+    return dateISOFormat;
+  }
+
+  getNumberInISOFornat(numberToFormat: number): string {
+    const limitSingleNumber = 9;
+    const isNumberGreaterThanLimitNumber = numberToFormat > limitSingleNumber;
+    const numberInISOFormat: string = isNumberGreaterThanLimitNumber ? numberToFormat.toString() : `0${numberToFormat}`;
+    return numberInISOFormat;
+  }
+
+  dateToSubmit(date: string, hour: string) {
+    const timeEntryISODate: string = get(this.entryToEdit, date);
+    let seconds = 0;
+    let miliseconds = 0;
+
+    if (timeEntryISODate) {
+      const timeEntryDate: Date = new Date(timeEntryISODate);
+      seconds = timeEntryDate.getSeconds();
+      miliseconds = timeEntryDate.getMilliseconds();
+    }
+
+    const newEntryDate: string = this.entryForm.value[date];
+    const newEntryHour: string = this.entryForm.value[hour];
+
+    const updatedDate: string = this.getDateISOFormat(newEntryDate, newEntryHour, seconds, miliseconds);
     const initialDate = get(this.entryToEdit, date, updatedDate);
-    const dateHasNotChanged = (initialDate === updatedDate);
+    const dateHasNotChanged = initialDate === updatedDate;
     const result = dateHasNotChanged ? initialDate : updatedDate;
     return result;
   }

--- a/src/app/modules/shared/components/details-fields/details-fields.component.ts
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.ts
@@ -264,15 +264,15 @@ export class DetailsFieldsComponent implements OnChanges, OnInit {
     return startDate >= endDate;
   }
 
-  getDateISOFormat(date: string, hourAndMinutes: string, seconds, miliseconds: number): string {
+  getDateISOFormat(date: string, hourAndMinutes: string, seconds: number, miliseconds: number): string {
     hourAndMinutes = hourAndMinutes.trim();
-    const secondsInISOFormat: string = this.getNumberInISOFornat(seconds);
-    const milisecondsInISOFormat: string = this.getNumberInISOFornat(miliseconds);
+    const secondsInISOFormat: string = this.getNumberInISOFormat(seconds);
+    const milisecondsInISOFormat: string = this.getNumberInISOFormat(miliseconds);
     const ISOFormat = `${date}T${hourAndMinutes}:${secondsInISOFormat}.${milisecondsInISOFormat}`;
     return new Date(ISOFormat).toISOString();
   }
 
-  getNumberInISOFornat(numberToFormat: number): string {
+  getNumberInISOFormat(numberToFormat: number): string {
     const limitSingleNumber = 9;
     const isNumberGreaterThanLimitNumber = numberToFormat > limitSingleNumber;
     return isNumberGreaterThanLimitNumber ? numberToFormat.toString() : `0${numberToFormat}`;

--- a/src/app/modules/shared/components/details-fields/details-fields.component.ts
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.ts
@@ -269,15 +269,13 @@ export class DetailsFieldsComponent implements OnChanges, OnInit {
     const secondsInISOFormat: string = this.getNumberInISOFornat(seconds);
     const milisecondsInISOFormat: string = this.getNumberInISOFornat(miliseconds);
     const ISOFormat = `${date}T${hourAndMinutes}:${secondsInISOFormat}.${milisecondsInISOFormat}`;
-    const dateISOFormat: string = new Date(ISOFormat).toISOString();
-    return dateISOFormat;
+    return new Date(ISOFormat).toISOString();
   }
 
   getNumberInISOFornat(numberToFormat: number): string {
     const limitSingleNumber = 9;
     const isNumberGreaterThanLimitNumber = numberToFormat > limitSingleNumber;
-    const numberInISOFormat: string = isNumberGreaterThanLimitNumber ? numberToFormat.toString() : `0${numberToFormat}`;
-    return numberInISOFormat;
+    return isNumberGreaterThanLimitNumber ? numberToFormat.toString() : `0${numberToFormat}`;
   }
 
   dateToSubmit(date: string, hour: string) {


### PR DESCRIPTION
## Description
Currently there is an error with some entries that does not allow to modify their start or end time, the error that is generated is the following:
![image](https://user-images.githubusercontent.com/56373098/129495295-4309f39d-014e-44f4-b5ac-c054ff3a477a.png)
 
When attempting to modify the following entries:
![image](https://user-images.githubusercontent.com/56373098/129495324-1b07773a-8b6f-4bba-836b-4fa9aa189c21.png)

This error occurs because in the current implementation to modify the entries they are not taking into account the seconds of the entries, in other words, only hours and minutes are taken into account.

## Solution
With this PR, this implementation has been fixed and now takes into account all the information of the start/end time of the entry.