### PR TITLE
TT-304 Handle message: the data could not be load

### DIFF
--- a/src/app/modules/time-entries/pages/time-entries.component.html
+++ b/src/app/modules/time-entries/pages/time-entries.component.html
@@ -54,12 +54,12 @@
             <th class="col"></th>
           </tr>
         </thead>
-        <tr *ngIf="checkIfDataSourceIsLoadingorEmpty(dataSource)">
+        <tr *ngIf="dataSource.isLoading">
           <td class="text-center" colspan="7">{{NO_DATA_MESSAGE}}</td>
         </tr>
         <app-loading-bar *ngIf="dataSource.isLoading"></app-loading-bar>
         <tbody *ngIf="!dataSource.isLoading">
-          <tr *ngIf="!checkIfDataSourceIsLoadingorEmpty(dataSource)">
+          <tr *ngIf="!dataSource?.data.length">
             <td class="text-center" colspan="7">{{NO_DATA_MESSAGE}}</td>
           </tr>
           <tr class="d-flex" *ngFor="let entry of dataSource.data">

--- a/src/app/modules/time-entries/pages/time-entries.component.html
+++ b/src/app/modules/time-entries/pages/time-entries.component.html
@@ -59,7 +59,7 @@
         </tr>
         <app-loading-bar *ngIf="dataSource.isLoading"></app-loading-bar>
         <tbody *ngIf="!dataSource.isLoading">
-          <tr *ngIf="checkIfDataSourceIsLoadingorEmpty(dataSource)">
+          <tr *ngIf="!checkIfDataSourceIsLoadingorEmpty(dataSource)">
             <td class="text-center" colspan="7">{{NO_DATA_MESSAGE}}</td>
           </tr>
           <tr class="d-flex" *ngFor="let entry of dataSource.data">

--- a/src/app/modules/time-entries/pages/time-entries.component.html
+++ b/src/app/modules/time-entries/pages/time-entries.component.html
@@ -42,7 +42,7 @@
   </ng-template>
   <ng-template #listView>
     <div id="listView">
-      <table class="table table-sm table-striped mb-0" datatable [dtTrigger]="dtTrigger" [dtOptions]="dtOptions" *ngIf="timeEntriesDataSource$ | async as dataSource">
+      <table class="table table-sm table-striped mb-0" *ngIf="timeEntriesDataSource$ | async as dataSource">
         <thead class="thead-blue">
           <tr class="d-flex">
             <th class="col">Date</th>
@@ -54,8 +54,14 @@
             <th class="col"></th>
           </tr>
         </thead>
+        <tr *ngIf="dataSource.isLoading">
+          <td class="text-center" colspan="7">No data available in table</td>
+        </tr>
         <app-loading-bar *ngIf="dataSource.isLoading"></app-loading-bar>
         <tbody *ngIf="!dataSource.isLoading">
+          <tr *ngIf="dataSource?.data.length === 0">
+            <td class="text-center" colspan="7">No data available in table</td>
+          </tr>
           <tr class="d-flex" *ngFor="let entry of dataSource.data">
             <td class="col">{{ entry.start_date | date: 'MM/dd/yyyy' }}</td>
             <td class="col">{{ entry.start_date | date: 'HH:mm' }} - {{ entry.end_date | date: 'HH:mm' }}</td>

--- a/src/app/modules/time-entries/pages/time-entries.component.html
+++ b/src/app/modules/time-entries/pages/time-entries.component.html
@@ -54,12 +54,12 @@
             <th class="col"></th>
           </tr>
         </thead>
-        <tr *ngIf="checkIfDataSourceIsLoading(dataSource)">
+        <tr *ngIf="checkIfDataSourceIsLoadingorEmpty(dataSource)">
           <td class="text-center" colspan="7">{{NO_DATA_MESSAGE}}</td>
         </tr>
         <app-loading-bar *ngIf="dataSource.isLoading"></app-loading-bar>
         <tbody *ngIf="!dataSource.isLoading">
-          <tr *ngIf="checkIfDataSourceIsEmpty(dataSource)">
+          <tr *ngIf="checkIfDataSourceIsLoadingorEmpty(dataSource)">
             <td class="text-center" colspan="7">{{NO_DATA_MESSAGE}}</td>
           </tr>
           <tr class="d-flex" *ngFor="let entry of dataSource.data">

--- a/src/app/modules/time-entries/pages/time-entries.component.html
+++ b/src/app/modules/time-entries/pages/time-entries.component.html
@@ -42,7 +42,7 @@
   </ng-template>
   <ng-template #listView>
     <div id="listView">
-      <table class="table table-sm table-striped mb-0" *ngIf="timeEntriesDataSource$ | async as dataSource">
+      <table class="table table-sm table-striped mb-0" datatable [dtTrigger]="dtTrigger" [dtOptions]="dtOptions" *ngIf="timeEntriesDataSource$ | async as dataSource">
         <thead class="thead-blue">
           <tr class="d-flex">
             <th class="col">Date</th>

--- a/src/app/modules/time-entries/pages/time-entries.component.html
+++ b/src/app/modules/time-entries/pages/time-entries.component.html
@@ -54,13 +54,13 @@
             <th class="col"></th>
           </tr>
         </thead>
-        <tr *ngIf="dataSource.isLoading">
-          <td class="text-center" colspan="7">No data available in table</td>
+        <tr *ngIf="checkIfDataSourceIsLoading(dataSource)">
+          <td class="text-center" colspan="7">{{NO_DATA_MESSAGE}}</td>
         </tr>
         <app-loading-bar *ngIf="dataSource.isLoading"></app-loading-bar>
         <tbody *ngIf="!dataSource.isLoading">
-          <tr *ngIf="dataSource?.data.length === 0">
-            <td class="text-center" colspan="7">No data available in table</td>
+          <tr *ngIf="checkIfDataSourceIsEmpty(dataSource)">
+            <td class="text-center" colspan="7">{{NO_DATA_MESSAGE}}</td>
           </tr>
           <tr class="d-flex" *ngFor="let entry of dataSource.data">
             <td class="col">{{ entry.start_date | date: 'MM/dd/yyyy' }}</td>

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -668,4 +668,11 @@ describe('TimeEntriesComponent', () => {
 
     expect(HTMLTimeEntriesView).not.toBeNull();
   });
+
+  it('after the component is initialized it should initialize the table', () => {
+    spyOn(component.dtTrigger, 'next');
+    component.ngAfterViewInit();
+
+    expect(component.dtTrigger.next).toHaveBeenCalled();
+  });
 });

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -670,14 +670,22 @@ describe('TimeEntriesComponent', () => {
   });
 
   it('checkIfDataSourceIsLoading should be false when dataSource.isLoading is false', () => {
-    const expectedValue = false;
-
-    expect(component.checkIfDataSourceIsLoading(state.timeEntriesDataSource)).toEqual(expectedValue);
+    expect(component.checkIfDataSourceIsLoading(state.timeEntriesDataSource)).toBeFalse();
   });
 
-  it('checkIfDataSourceIsEmpty should be false when dataSource.data.length is not zero', () => {
-    const expectedValue = false;
+  it('checkIfDataSourceIsLoading should be true when dataSource.isLoading is true', () => {
+    state.timeEntriesDataSource.isLoading = true;
 
-    expect(component.checkIfDataSourceIsEmpty(state.timeEntriesDataSource)).toEqual(expectedValue);
+    expect(component.checkIfDataSourceIsLoading(state.timeEntriesDataSource)).toBeTrue();
+  });
+
+  it('checkIfDataSourceIsEmpty should be false when dataSource.data.length is not empty', () => {
+    expect(component.checkIfDataSourceIsEmpty(state.timeEntriesDataSource)).toBeFalse();
+  });
+
+  it('checkIfDataSourceIsEmpty should be true when dataSource.data.length is empty', () => {
+    state.timeEntriesDataSource.data = [];
+
+    expect(component.checkIfDataSourceIsEmpty(state.timeEntriesDataSource)).toBeTrue();
   });
 });

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -668,14 +668,4 @@ describe('TimeEntriesComponent', () => {
 
     expect(HTMLTimeEntriesView).not.toBeNull();
   });
-
-  it('checkIfDataSourceIsLoadingorEmpty should be true when dataSource is Loading and data is not empty', () => {
-    state.timeEntriesDataSource.isLoading = true;
-    state.timeEntriesDataSource.data = [];
-    expect(component.checkIfDataSourceIsLoadingorEmpty(state.timeEntriesDataSource)).toBeTrue();
-  });
-
-  it('checkIfDataSourceIsLoadingorEmpty should be false when just dataSource.data.length is empty', () => {
-    expect(component.checkIfDataSourceIsLoadingorEmpty(state.timeEntriesDataSource)).toBeFalse();
-  });
 });

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -668,4 +668,16 @@ describe('TimeEntriesComponent', () => {
 
     expect(HTMLTimeEntriesView).not.toBeNull();
   });
+
+  it('checkIfDataSourceIsLoading should be false when dataSource.isLoading is false', () => {
+    const expectedValue = false;
+
+    expect(component.checkIfDataSourceIsLoading(state.timeEntriesDataSource)).toEqual(expectedValue);
+  });
+
+  it('checkIfDataSourceIsEmpty should be false when dataSource.data.length is not zero', () => {
+    const expectedValue = false;
+
+    expect(component.checkIfDataSourceIsEmpty(state.timeEntriesDataSource)).toEqual(expectedValue);
+  });
 });

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -668,11 +668,4 @@ describe('TimeEntriesComponent', () => {
 
     expect(HTMLTimeEntriesView).not.toBeNull();
   });
-
-  it('after the component is initialized it should initialize the table', () => {
-    spyOn(component.dtTrigger, 'next');
-    component.ngAfterViewInit();
-
-    expect(component.dtTrigger.next).toHaveBeenCalled();
-  });
 });

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -669,23 +669,13 @@ describe('TimeEntriesComponent', () => {
     expect(HTMLTimeEntriesView).not.toBeNull();
   });
 
-  it('checkIfDataSourceIsLoading should be false when dataSource.isLoading is false', () => {
-    expect(component.checkIfDataSourceIsLoadingorEmpty(state.timeEntriesDataSource)).toBeFalse();
-  });
-
-  it('checkIfDataSourceIsLoading should be true when dataSource.isLoading is true', () => {
+  it('checkIfDataSourceIsLoadingorEmpty should be true when dataSource is Loading and data is not empty', () => {
     state.timeEntriesDataSource.isLoading = true;
-
-    expect(component.checkIfDataSourceIsLoadingorEmpty(state.timeEntriesDataSource)).toBeTrue();
-  });
-
-  it('checkIfDataSourceIsEmpty should be false when dataSource.data.length is not empty', () => {
-    expect(component.checkIfDataSourceIsLoadingorEmpty(state.timeEntriesDataSource)).toBeFalse();
-  });
-
-  it('checkIfDataSourceIsEmpty should be true when dataSource.data.length is empty', () => {
     state.timeEntriesDataSource.data = [];
-
     expect(component.checkIfDataSourceIsLoadingorEmpty(state.timeEntriesDataSource)).toBeTrue();
+  });
+
+  it('checkIfDataSourceIsLoadingorEmpty should be false when just dataSource.data.length is empty', () => {
+    expect(component.checkIfDataSourceIsLoadingorEmpty(state.timeEntriesDataSource)).toBeFalse();
   });
 });

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -670,22 +670,22 @@ describe('TimeEntriesComponent', () => {
   });
 
   it('checkIfDataSourceIsLoading should be false when dataSource.isLoading is false', () => {
-    expect(component.checkIfDataSourceIsLoading(state.timeEntriesDataSource)).toBeFalse();
+    expect(component.checkIfDataSourceIsLoadingorEmpty(state.timeEntriesDataSource)).toBeFalse();
   });
 
   it('checkIfDataSourceIsLoading should be true when dataSource.isLoading is true', () => {
     state.timeEntriesDataSource.isLoading = true;
 
-    expect(component.checkIfDataSourceIsLoading(state.timeEntriesDataSource)).toBeTrue();
+    expect(component.checkIfDataSourceIsLoadingorEmpty(state.timeEntriesDataSource)).toBeTrue();
   });
 
   it('checkIfDataSourceIsEmpty should be false when dataSource.data.length is not empty', () => {
-    expect(component.checkIfDataSourceIsEmpty(state.timeEntriesDataSource)).toBeFalse();
+    expect(component.checkIfDataSourceIsLoadingorEmpty(state.timeEntriesDataSource)).toBeFalse();
   });
 
   it('checkIfDataSourceIsEmpty should be true when dataSource.data.length is empty', () => {
     state.timeEntriesDataSource.data = [];
 
-    expect(component.checkIfDataSourceIsEmpty(state.timeEntriesDataSource)).toBeTrue();
+    expect(component.checkIfDataSourceIsLoadingorEmpty(state.timeEntriesDataSource)).toBeTrue();
   });
 });

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -1,7 +1,7 @@
-import { Component, OnDestroy, OnInit, ViewChild, AfterViewInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActionsSubject, select, Store } from '@ngrx/store';
 import { ToastrService } from 'ngx-toastr';
-import { Observable, Subscription, Subject } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { delay, filter } from 'rxjs/operators';
 import { ProjectSelectedEvent } from '../../shared/components/details-fields/project-selected-event';
 import { SaveEntryEvent } from '../../shared/components/details-fields/save-entry-event';
@@ -14,13 +14,12 @@ import { EntryActionTypes } from './../../time-clock/store/entry.actions';
 import { getActiveTimeEntry, getTimeEntriesDataSource } from './../../time-clock/store/entry.selectors';
 import { CookieService } from 'ngx-cookie-service';
 import { FeatureToggle } from './../../../../environments/enum';
-import { DataTableDirective } from 'angular-datatables';
 @Component({
   selector: 'app-time-entries',
   templateUrl: './time-entries.component.html',
   styleUrls: ['./time-entries.component.scss'],
 })
-export class TimeEntriesComponent implements OnInit, OnDestroy, AfterViewInit {
+export class TimeEntriesComponent implements OnInit, OnDestroy {
   entryId: string;
   entry: Entry;
   activeTimeEntry: Entry;
@@ -39,11 +38,6 @@ export class TimeEntriesComponent implements OnInit, OnDestroy, AfterViewInit {
   selectedYear: number;
   selectedMonthAsText: string;
   isActiveEntryOverlapping = false;
-  dtOptions: any = {};
-  dtTrigger: Subject<any> = new Subject();
-  @ViewChild(DataTableDirective, { static: false })
-  dtElement: DataTableDirective;
-  rerenderTableSubscription: Subscription;
   constructor(
     private store: Store<EntryState>,
     private toastrService: ToastrService,
@@ -55,18 +49,8 @@ export class TimeEntriesComponent implements OnInit, OnDestroy, AfterViewInit {
   }
   ngOnDestroy(): void {
     this.entriesSubscription.unsubscribe();
-    this.rerenderTableSubscription.unsubscribe();
-    this.dtTrigger.unsubscribe();
   }
   ngOnInit(): void {
-    this.dtOptions = {
-      scrollY: '325px',
-      paging: false,
-      responsive: true,
-    };
-    this.rerenderTableSubscription = this.timeEntriesDataSource$.subscribe((ds) => {
-      this.rerenderDataTable();
-    });
     this.loadActiveEntry();
     this.isFeatureToggleCalendarActive = (this.cookiesService.get(FeatureToggle.TIME_TRACKER_CALENDAR) === 'true');
     this.entriesSubscription = this.actionsSubject$.pipe(
@@ -80,9 +64,6 @@ export class TimeEntriesComponent implements OnInit, OnDestroy, AfterViewInit {
       this.loadActiveEntry();
       this.store.dispatch(new entryActions.LoadEntries(this.selectedMonth, this.selectedYear));
     });
-  }
-  ngAfterViewInit(): void {
-    this.rerenderDataTable();
   }
   newEntry() {
     if (this.wasEditingExistingTimeEntry) {
@@ -233,17 +214,6 @@ export class TimeEntriesComponent implements OnInit, OnDestroy, AfterViewInit {
         });
         this.isActiveEntryOverlapping = overlappingEntry ? true : false;
       });
-    }
-  }
-
-  private rerenderDataTable(): void {
-    if (this.dtElement && this.dtElement.dtInstance) {
-      this.dtElement.dtInstance.then((dtInstance: DataTables.Api) => {
-          dtInstance.destroy();
-          this.dtTrigger.next();
-      });
-    } else {
-        this.dtTrigger.next();
     }
   }
 }

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -220,7 +220,7 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
   }
 
   checkIfDataSourceIsLoadingorEmpty(source?: DataSource<Entry>): boolean {
-    if (source.isLoading || source.data.length === 0) {
+    if (source.isLoading && source.data.length === 0) {
       return true;
     }
     return false;

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -219,15 +219,8 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
     }
   }
 
-  checkIfDataSourceIsLoading(data: DataSource<Entry>): boolean {
-    if (data.isLoading) {
-      return true;
-    }
-    return false;
-  }
-
-  checkIfDataSourceIsEmpty(data: DataSource<Entry>): boolean {
-    if (data.data.length === 0) {
+  checkIfDataSourceIsLoadingorEmpty(source?: DataSource<Entry>): boolean {
+    if (source.isLoading || source.data.length === 0) {
       return true;
     }
     return false;

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -218,11 +218,4 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
       });
     }
   }
-
-  checkIfDataSourceIsLoadingorEmpty(source?: DataSource<Entry>): boolean {
-    if (source.isLoading && source.data.length === 0) {
-      return true;
-    }
-    return false;
-  }
 }

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -38,6 +38,8 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
   selectedYear: number;
   selectedMonthAsText: string;
   isActiveEntryOverlapping = false;
+  readonly NO_DATA_MESSAGE: string = 'No data available in table';
+  timeEntry: DataSource<Entry>;
   constructor(
     private store: Store<EntryState>,
     private toastrService: ToastrService,
@@ -215,5 +217,19 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
         this.isActiveEntryOverlapping = overlappingEntry ? true : false;
       });
     }
+  }
+
+  checkIfDataSourceIsLoading(data: DataSource<Entry>): boolean {
+    if (data.isLoading) {
+      return true;
+    }
+    return false;
+  }
+
+  checkIfDataSourceIsEmpty(data: DataSource<Entry>): boolean {
+    if (data.data.length === 0) {
+      return true;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
# Problem
In the time-entries section, when there is no data, the message "The data could not be load" is displayed.
![Error-dataMessage](https://user-images.githubusercontent.com/12177501/129948317-7e7a2bf3-3110-41a5-871b-bb83b5efa7bd.png)
# Solution
When there is no data, instead of the message "The data could not be load", the message "No data available in table" should be displayed in the table section. That is the purpose of this pull request.
![solution-errorMessage](https://user-images.githubusercontent.com/12177501/129948685-8fecfd53-7923-4b34-bcf8-26798816cb62.jpeg)