### PR TITLE
fix: TT-313 run unit tests before commiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commit-message-validator",
-      "pre-commit": "ng lint"
+      "pre-commit": "ng lint && ng test --watch=false --browsers=ChromeHeadless"
     }
   },
   "config": {


### PR DESCRIPTION
### Observation
It would be better if we run unit tests before commiting, and only commit and push after tests are successful.


### Solution

To do so, on the package.json file it was needed just to modify the husky configuration as follows:
```
"husky": {
    "hooks": {
      "commit-msg": "commit-message-validator",
      "pre-commit": "ng lint && ng test --watch=false --browsers=ChromeHeadless"
    }
  }
```