### PR TITLE
style: TT-315 Fixed headers days of the week

### DIFF
--- a/src/app/modules/time-entries/components/calendar/calendar.component.html
+++ b/src/app/modules/time-entries/components/calendar/calendar.component.html
@@ -144,6 +144,7 @@
       [viewDate]="currentDate"
       [events]="timeEntriesAsEvent"
       [cellTemplate]="timeEntriesInsideMonthCalendarTemplate"
+      [weekStartsOn]="WEEK_START_DAY"
     >
     </mwl-calendar-month-view>
     <mwl-calendar-week-view
@@ -152,6 +153,7 @@
       [events]="timeEntriesAsEvent"
       [hourSegmentHeight]="HALF_HOUR * VARIATION_HEIGHT"
       [eventTemplate]="timeEntriesInsideDaysCalendarTemplate"
+      [weekStartsOn]="WEEK_START_DAY"
     >
     </mwl-calendar-week-view>
     <mwl-calendar-day-view

--- a/src/app/modules/time-entries/components/calendar/calendar.component.scss
+++ b/src/app/modules/time-entries/components/calendar/calendar.component.scss
@@ -70,6 +70,7 @@ $activity-text-size: $max-lines-activity * $line-height-base;
     overflow-y: hidden;
     color: $primary-text;
     margin: 2px 6px 0px 5px;
+    overflow-wrap: anywhere;
     background-color: $background-card-entry;
     border-left: 5px solid calculate-border-color($background-card-entry);
     -webkit-box-shadow: 0px 2px 5px 0px lighten($shadow-card-entry, 50%);
@@ -91,7 +92,7 @@ $activity-text-size: $max-lines-activity * $line-height-base;
     }
 
     p.additional {
-      overflow-wrap: break-word;
+      overflow-wrap: anywhere;
       color: calculate-bold-text-color($primary-text);
     }
   }
@@ -154,13 +155,13 @@ $activity-text-size: $max-lines-activity * $line-height-base;
   }
 }
 
-.btn-navigation{
+.btn-navigation {
   padding-left: 6px;
   padding-right: 6px;
 }
 
-@media only screen and (min-width : 576px) and (max-width : 767px) {
-  .currentDate{
+@media only screen and (min-width: 576px) and (max-width: 767px) {
+  .currentDate {
     margin-left: 14px;
     p {
       margin: 0;

--- a/src/app/modules/time-entries/components/calendar/calendar.component.ts
+++ b/src/app/modules/time-entries/components/calendar/calendar.component.ts
@@ -8,7 +8,7 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
-import { CalendarEvent, CalendarView } from 'angular-calendar';
+import { CalendarEvent, CalendarView, DAYS_OF_WEEK } from 'angular-calendar';
 import { Observable } from 'rxjs';
 import * as moment from 'moment';
 import { DataSource } from '../../../shared/models/data-source.model';
@@ -28,6 +28,7 @@ export class CalendarComponent implements OnInit {
   readonly VARIATION_HEIGHT: number = 2;
   readonly VISIBLE_TARGETS_FOR_TIME_ENTRIES_DESCRIPTION: CalendarView[] = [CalendarView.Week, CalendarView.Day];
   readonly CALENDAR_VIEW_ENUM: typeof CalendarView = CalendarView;
+  readonly WEEK_START_DAY = DAYS_OF_WEEK.MONDAY;
 
   @ViewChild('scrollContainer') scrollContainer: ElementRef<HTMLElement>;
 

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -39,7 +39,6 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
   selectedMonthAsText: string;
   isActiveEntryOverlapping = false;
   readonly NO_DATA_MESSAGE: string = 'No data available in table';
-  timeEntry: DataSource<Entry>;
   constructor(
     private store: Store<EntryState>,
     private toastrService: ToastrService,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -43,3 +43,21 @@ Overwritten calendar style
 .cal-today:hover {
   background-color: darken($background-calendar-cell, 7%) !important;
 }
+
+.cal-week-view .cal-day-headers {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: $background-calendar-cell;
+}
+
+.cal-month-view .cal-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: $background-calendar-cell;
+}
+
+.cal-header .cal-cell {
+  border: 0.1px solid lighten($primary-text, 30%);
+}


### PR DESCRIPTION
# Problem
As Time-tracker is working now, there are a few problems with the calendar feature in the Time entries section.

The problems are:

**1.- In the month view, when we scroll down, the days of the week disappear:**

![Problema_cabeceras_mes](https://user-images.githubusercontent.com/12177501/130386301-cb908af0-db52-4115-a353-82267fde5a7b.jpeg)

**2.- The same problem described above occurs in the week view section:**

![Problema_headers_weekview](https://user-images.githubusercontent.com/12177501/130387145-9f889b0b-b5c4-436b-9b61-161d5369e10e.jpeg)

**3.- Also, in the month view, when we decrease the size of the screen, the time entries are not responsive:**

![Problema_mes_responsive](https://user-images.githubusercontent.com/12177501/130386702-d7803c34-2d70-4095-b6b3-0e76c4351eb5.jpeg)

# Solution
For the problems listed before, the solutions are:

**1.- In this pull request, no matter how deep we scroll in the calendar, the days of the week stay fixed as a header:**

![Captura de Pantalla 2021-08-22 a la(s) 22 46 18](https://user-images.githubusercontent.com/12177501/130387555-722bfd0f-0f31-4c5f-9186-a515a4d7380d.png)

**2.- The solution in the previous point also applies to the week section:**

![Captura de Pantalla 2021-08-22 a la(s) 22 52 36](https://user-images.githubusercontent.com/12177501/130387744-315b35bb-5a30-4228-a074-f6b3228c721f.png)

**3.- In terms of the time entries, when there is a reduction in the screen size, time entries decrease its size as well:**

![Captura de Pantalla 2021-08-22 a la(s) 22 58 44](https://user-images.githubusercontent.com/12177501/130388214-917f2c13-8645-482d-92ec-ec483ba9375b.png)

**Note:**
**As a bonus in this pull request, Monday became the first day of the week instead of Sunday.**