### PR TITLE
style: TT-320 Improve customers and users tables

### DIFF
--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.html
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.html
@@ -10,7 +10,7 @@
         <th class="hidden-col">ID</th>
         <th class="col md-col">User email</th>
         <th class="col sm-col">Date</th>
-        <th class="col x-sm-col" title="Duration (hours)">Duration (hours)</th>
+        <th class="col sm-col" title="Duration (hours)">Duration</th>
         <th class="col x-sm-col" title="Time in">Time in</th>
         <th class="col x-sm-col" title="Time out">Time out</th>
         <th class="col md-col">Project</th>
@@ -31,7 +31,7 @@
         <td class="col sm-col">
           {{ entry.start_date | date: 'MM/dd/yyyy' }}
         </td>
-        <td class="col x-sm-col">
+        <td class="col sm-col">
           {{ entry.end_date | substractDate: entry.start_date }}
         </td>
         <td class="col x-sm-col">{{ entry.start_date | date: 'HH:mm' }}</td>

--- a/src/app/modules/users/components/users-list/users-list.component.html
+++ b/src/app/modules/users/components/users-list/users-list.component.html
@@ -7,16 +7,16 @@
     [dtOptions]="dtOptions">
     <thead class="thead-blue">
       <tr class="d-flex flex-wrap">
-        <th class="col-4">User Email</th>
         <th class="col-5">Names</th>
+        <th class="col-4">User Email</th>
         <th class="col-3">Groups</th>
       </tr>
     </thead>
     <app-loading-bar *ngIf="isLoading$ | async"></app-loading-bar>
     <tbody>
       <tr class="d-flex flex-wrap" *ngFor="let user of users">
-        <td class="col-4 text-break">{{ user.email }}</td>
         <td class="col-5 text-break">{{ user.name }}</td>
+        <td class="col-4 text-break">{{ user.email }}</td>
         <td class="col-3 text-center">
           <ui-switch
             size="small"


### PR DESCRIPTION
# Problem
1. In the Users section, there is a table with the following columns: User email, Names, and Groups. This is not so useful, because the names of the users should go first:

![Captura de Pantalla 2021-08-23 a la(s) 20 16 20](https://user-images.githubusercontent.com/12177501/130540039-d0f50c40-e844-499c-b753-a175f5ae9a33.png)

2. In the Reports section, the Duration column is not showing all its letters, it seems like there is a problem with the name of the column:

![Captura de Pantalla 2021-08-23 a la(s) 20 22 47](https://user-images.githubusercontent.com/12177501/130540767-0735feb1-4dd7-48db-b402-c2b539cab09c.png)

# Solution

1. A switch between the Email column and the Names column has been made to improve the user experience:

![Captura de Pantalla 2021-08-23 a la(s) 20 16 08](https://user-images.githubusercontent.com/12177501/130540986-0cca1b35-585d-4a41-ae78-13be77e1d83c.png)

2. The Duration column now is showing all its letters:

![Captura de Pantalla 2021-08-23 a la(s) 20 31 47](https://user-images.githubusercontent.com/12177501/130541095-c9af34b7-325b-428e-9d85-1b6db0066c24.png)
