### PR TITLE
Tt 319 fix calendar day week view

### DIFF
--- a/src/app/modules/time-entries/components/calendar/calendar.component.spec.ts
+++ b/src/app/modules/time-entries/components/calendar/calendar.component.spec.ts
@@ -200,8 +200,7 @@ describe('CalendarComponent', () => {
   it('emit current date and call navigationEnable when call handleChangeDateEvent', () => {
     const calendarView: CalendarView = CalendarView.Month;
     const fakeValueEmit = {
-      date: currentDate.toDate(),
-      calendarView
+      date: currentDate.toDate()
     };
     spyOn(component, 'navigationEnable');
     spyOn(component.changeDate, 'emit');
@@ -220,6 +219,14 @@ describe('CalendarComponent', () => {
     component.changeCalendarView(CalendarView.Day);
 
     expect(component.calendarView).toEqual(fakeCalendarView);
+  });
+
+  it('emit calendarView Day when call changeCalendarView', () => {
+    const fakeCalendarView: CalendarView = CalendarView.Day;
+    component.calendarView = CalendarView.Month;
+    spyOn(component.changeView, 'emit');
+    component.changeCalendarView(fakeCalendarView);
+    expect(component.changeView.emit).toHaveBeenCalledWith({ calendarView: fakeCalendarView });
   });
 
   it('set srcoll to current time marker in calendarView when is call scrollToCurrentTimeMarker', () => {

--- a/src/app/modules/time-entries/components/calendar/calendar.component.spec.ts
+++ b/src/app/modules/time-entries/components/calendar/calendar.component.spec.ts
@@ -198,10 +198,11 @@ describe('CalendarComponent', () => {
   });
 
   it('emit current date and call navigationEnable when call handleChangeDateEvent', () => {
+    const calendarView: CalendarView = CalendarView.Month;
     const fakeValueEmit = {
       date: currentDate.toDate(),
+      calendarView
     };
-    const calendarView = CalendarView.Month;
     spyOn(component, 'navigationEnable');
     spyOn(component.changeDate, 'emit');
     spyOn(component, 'isVisibleForCurrentDate');

--- a/src/app/modules/time-entries/components/calendar/calendar.component.ts
+++ b/src/app/modules/time-entries/components/calendar/calendar.component.ts
@@ -44,6 +44,9 @@ export class CalendarComponent implements OnInit {
   @Output() changeDate: EventEmitter<any> = new EventEmitter<{
     date: Date;
   }>();
+  @Output() changeView: EventEmitter<any> = new EventEmitter<{
+    calendarView: CalendarView;
+  }>();
 
   initialDate: Date;
   previusDate: Date;
@@ -109,7 +112,7 @@ export class CalendarComponent implements OnInit {
     const date = this.currentDate;
     this.isToday = this.isVisibleForCurrentDate();
     this.navigationEnable(this.calendarView);
-    this.changeDate.emit({ date, calendarView: this.calendarView });
+    this.changeDate.emit({ date });
   }
 
   changeCalendarView(calendarView: CalendarView) {
@@ -119,6 +122,7 @@ export class CalendarComponent implements OnInit {
       this.referenceChangeDetector.detectChanges();
       this.scrollToCurrentTimeMarker();
     }
+    this.changeView.emit({ calendarView });
   }
 
   navigationEnable(calendarView: CalendarView) {

--- a/src/app/modules/time-entries/components/calendar/calendar.component.ts
+++ b/src/app/modules/time-entries/components/calendar/calendar.component.ts
@@ -109,7 +109,7 @@ export class CalendarComponent implements OnInit {
     const date = this.currentDate;
     this.isToday = this.isVisibleForCurrentDate();
     this.navigationEnable(this.calendarView);
-    this.changeDate.emit({ date });
+    this.changeDate.emit({ date, calendarView: this.calendarView });
   }
 
   changeCalendarView(calendarView: CalendarView) {

--- a/src/app/modules/time-entries/pages/time-entries.component.html
+++ b/src/app/modules/time-entries/pages/time-entries.component.html
@@ -34,6 +34,7 @@
           [currentDate]="selectedDate.toDate()"
           [calendarView]="calendarView"
           (changeDate)="changeDate($event)"
+          (changeView)="changeView($event)"
           (viewModal)="editEntry($event.id)"
           (deleteTimeEntry)="openModal($event.timeEntry)"
         >

--- a/src/app/modules/time-entries/pages/time-entries.component.html
+++ b/src/app/modules/time-entries/pages/time-entries.component.html
@@ -32,6 +32,7 @@
           *ngIf="!dataSource.isLoading"
           [timeEntries$]="timeEntriesDataSource$"
           [currentDate]="selectedDate.toDate()"
+          [calendarView]="calendarView"
           (changeDate)="changeDate($event)"
           (viewModal)="editEntry($event.id)"
           (deleteTimeEntry)="openModal($event.timeEntry)"

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -561,6 +561,7 @@ describe('TimeEntriesComponent', () => {
     const dateMoment: moment.Moment = moment().month(monthIndex).year(year);
     jasmine.clock().mockDate(dateMoment.toDate());
 
+    component.currentMonth = monthIndex;
     component.dateSelected(eventData);
 
     expect(component.selectedDate).toEqual(dateMoment);
@@ -569,10 +570,8 @@ describe('TimeEntriesComponent', () => {
   it('set date in selectedDate when call changeDate and selectedDate.month() is same to incoming date', () => {
     const incomingDate = new Date('2021-06-07');
     const incomingMoment: moment.Moment = moment(incomingDate);
-    const calendarView: CalendarView = CalendarView.Month;
     const eventData = {
-      date: incomingDate,
-      calendarView
+      date: incomingDate
     };
     spyOn(component, 'dateSelected');
     component.selectedDate = moment(incomingMoment).subtract(1, 'day');
@@ -586,10 +585,8 @@ describe('TimeEntriesComponent', () => {
   it('call dateSelected when call changeDate and selectedDate.month() is different to incoming date', () => {
     const incomingDate = new Date('2021-01-07');
     const incomingMoment: moment.Moment = moment(incomingDate);
-    const calendarView: CalendarView = CalendarView.Month;
     const eventData = {
-      date: incomingDate,
-      calendarView
+      date: incomingDate
     };
     const selectedDate = {
       monthIndex: incomingMoment.month(),
@@ -601,6 +598,40 @@ describe('TimeEntriesComponent', () => {
     component.changeDate(eventData);
 
     expect(component.dateSelected).toHaveBeenCalledWith(selectedDate);
+  });
+
+  it('change component selectedDate to be the first day of the month when call dateSelected', () => {
+    const actualMoment: moment.Moment = moment(new Date('2021-01-07'));
+    const selectedMoment: moment.Moment = moment(new Date('2021-05-13'));
+    const firstDayMoment: moment.Moment = selectedMoment.startOf('month');
+    const eventDate = {
+      monthIndex: selectedMoment.month(),
+      year: selectedMoment.year()
+    };
+    component.currentMonth = actualMoment.month();
+    component.selectedDate = selectedMoment;
+    spyOn(component, 'dateSelected');
+    component.dateSelected(eventDate);
+    expect(component.selectedDate).toBe(firstDayMoment);
+  });
+
+  it('change component calendarView from Month to Day when call changeView', () => {
+    const fakeCalendarView: CalendarView = CalendarView.Day;
+    const eventView = {
+      calendarView: fakeCalendarView
+    };
+    component.calendarView = CalendarView.Month;
+    component.changeView(eventView);
+    expect(component.calendarView).toBe(fakeCalendarView);
+  });
+
+  it('change component calendarView to Month if undefined when call changeView', () => {
+    component.calendarView = CalendarView.Week;
+    const eventView = {
+      calendarView: undefined
+    };
+    component.changeView(eventView);
+    expect(component.calendarView).toBe(CalendarView.Month);
   });
 
   it('not view button onDisplayModeChange when isFeatureToggleCalendarActive is false', () => {

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -21,6 +21,7 @@ import { NgxMaterialTimepickerModule } from 'ngx-material-timepicker';
 import { CookieService } from 'ngx-cookie-service';
 import { DebugElement } from '@angular/core';
 import { FeatureToggle } from './../../../../environments/enum';
+import { CalendarView } from 'angular-calendar';
 import * as moment from 'moment';
 
 describe('TimeEntriesComponent', () => {
@@ -568,8 +569,10 @@ describe('TimeEntriesComponent', () => {
   it('set date in selectedDate when call changeDate and selectedDate.month() is same to incoming date', () => {
     const incomingDate = new Date('2021-06-07');
     const incomingMoment: moment.Moment = moment(incomingDate);
+    const calendarView: CalendarView = CalendarView.Month;
     const eventData = {
       date: incomingDate,
+      calendarView
     };
     spyOn(component, 'dateSelected');
     component.selectedDate = moment(incomingMoment).subtract(1, 'day');
@@ -583,8 +586,10 @@ describe('TimeEntriesComponent', () => {
   it('call dateSelected when call changeDate and selectedDate.month() is different to incoming date', () => {
     const incomingDate = new Date('2021-01-07');
     const incomingMoment: moment.Moment = moment(incomingDate);
+    const calendarView: CalendarView = CalendarView.Month;
     const eventData = {
       date: incomingDate,
+      calendarView
     };
     const selectedDate = {
       monthIndex: incomingMoment.month(),

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -40,6 +40,7 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
   selectedMonthAsText: string;
   isActiveEntryOverlapping = false;
   calendarView: CalendarView = CalendarView.Month;
+  currentMonth = moment().month();
   readonly NO_DATA_MESSAGE: string = 'No data available in table';
   constructor(
     private store: Store<EntryState>,
@@ -182,9 +183,12 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
     this.selectedMonthAsText = moment().month(event.monthIndex).format('MMMM');
     this.store.dispatch(new entryActions.LoadEntries(this.selectedMonth, this.selectedYear));
     this.selectedDate = moment().month(event.monthIndex).year(event.year);
+    if (this.currentMonth !== event.monthIndex){
+      this.selectedDate = this.selectedDate.startOf('month');
+    }
   }
 
-  changeDate(event: { date: Date, calendarView: CalendarView }){
+  changeDate(event: { date: Date }){
     const newDate: moment.Moment = moment(event.date);
     if (this.selectedDate.month() !== newDate.month()){
       const monthSelected = newDate.month();
@@ -196,7 +200,10 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
       this.dateSelected(selectedDate);
     }
     this.selectedDate = newDate;
-    this.calendarView = event.calendarView;
+  }
+
+  changeView(event: { calendarView: CalendarView }){
+    this.calendarView = event.calendarView || CalendarView.Month;
   }
 
   openModal(item: any) {

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -14,6 +14,7 @@ import { EntryActionTypes } from './../../time-clock/store/entry.actions';
 import { getActiveTimeEntry, getTimeEntriesDataSource } from './../../time-clock/store/entry.selectors';
 import { CookieService } from 'ngx-cookie-service';
 import { FeatureToggle } from './../../../../environments/enum';
+import { CalendarView } from 'angular-calendar';
 @Component({
   selector: 'app-time-entries',
   templateUrl: './time-entries.component.html',
@@ -38,6 +39,7 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
   selectedYear: number;
   selectedMonthAsText: string;
   isActiveEntryOverlapping = false;
+  calendarView: CalendarView = CalendarView.Month;
   readonly NO_DATA_MESSAGE: string = 'No data available in table';
   constructor(
     private store: Store<EntryState>,
@@ -182,7 +184,7 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
     this.selectedDate = moment().month(event.monthIndex).year(event.year);
   }
 
-  changeDate(event: { date: Date }){
+  changeDate(event: { date: Date, calendarView: CalendarView }){
     const newDate: moment.Moment = moment(event.date);
     if (this.selectedDate.month() !== newDate.month()){
       const monthSelected = newDate.month();
@@ -194,6 +196,7 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
       this.dateSelected(selectedDate);
     }
     this.selectedDate = newDate;
+    this.calendarView = event.calendarView;
   }
 
   openModal(item: any) {


### PR DESCRIPTION
# **Problem**
When entering to the time entries section → calendar option → and navigating through the months on week and day views, the system automatically changes to the month view again because it renders the component again every time we change to the previous or next month. Also every time we select a month from the month picker it select the actual day (e.g: if today is January 24 and select May it navigates to May 24)

# **Solution**
Now the component keeps the actual day, week or month view, so even if it renders again it keeps the view. Now when we select another month from the month picker it changes to the first day of that month.

![image](https://user-images.githubusercontent.com/41339889/130705757-c63b5d8a-00db-48f7-af54-6f96306af912.png)

