### PR TITLE
Tt 318 improve column visibility section

### DIFF
--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
@@ -33,13 +33,6 @@ export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewIn
       {
         extend: 'excel',
         exportOptions: {
-          format: {
-            body: (data, column) => {
-              return column.name === 'Duration' ?
-              moment.duration(data).asHours().toFixed(4).slice(0, -1) :
-              data;
-            },
-          },
           columns: ':visible'
         },
         text: 'Excel',
@@ -48,13 +41,6 @@ export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewIn
       {
         extend: 'csv',
         exportOptions: {
-          format: {
-            body: (data, column) => {
-              return column.name === 'Duration' ?
-              moment.duration(data).asHours().toFixed(4).slice(0, -1) :
-              data;
-            },
-          },
           columns: ':visible'
         },
         text: 'CSV',

--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
@@ -34,29 +34,31 @@ export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewIn
         extend: 'excel',
         exportOptions: {
           format: {
-            body: (data, row, column, node) => {
-              return column === 3 ?
+            body: (data, column) => {
+              return column.name === 'Duration' ?
               moment.duration(data).asHours().toFixed(4).slice(0, -1) :
               data;
             },
           },
+          columns: ':visible'
         },
         text: 'Excel',
-        filename: `time-entries-${formatDate(new Date(), 'MM_dd_yyyy-HH_mm', 'en')}`,
+        filename: `time-entries-${formatDate(new Date(), 'MM_dd_yyyy-HH_mm', 'en')}`
       },
       {
         extend: 'csv',
         exportOptions: {
           format: {
-            body: (data, row, column, node) => {
-              return column === 3 ?
+            body: (data, column) => {
+              return column.name === 'Duration' ?
               moment.duration(data).asHours().toFixed(4).slice(0, -1) :
               data;
             },
           },
+          columns: ':visible'
         },
         text: 'CSV',
-        filename: `time-entries-${formatDate(new Date(), 'MM_dd_yyyy-HH_mm', 'en')}`,
+        filename: `time-entries-${formatDate(new Date(), 'MM_dd_yyyy-HH_mm', 'en')}`
       },
     ]
   };

--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
@@ -22,9 +22,14 @@ export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewIn
     buttons: [
       {
         extend: 'colvis',
-        columns: ':not(.hidden-col)',
+        columns: ':not(.hidden-col),visible'
       },
-      'print',
+      {
+        extend: 'print',
+        exportOptions: {
+          columns: ':visible'
+          }
+      },
       {
         extend: 'excel',
         exportOptions: {
@@ -53,7 +58,7 @@ export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewIn
         text: 'CSV',
         filename: `time-entries-${formatDate(new Date(), 'MM_dd_yyyy-HH_mm', 'en')}`,
       },
-    ],
+    ]
   };
   dtTrigger: Subject<any> = new Subject();
   @ViewChild(DataTableDirective, { static: false })

--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
@@ -2,7 +2,6 @@ import { formatDate } from '@angular/common';
 import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import { select, Store } from '@ngrx/store';
 import { DataTableDirective } from 'angular-datatables';
-import * as moment from 'moment';
 import { Observable, Subject, Subscription } from 'rxjs';
 import { Entry } from 'src/app/modules/shared/models';
 import { DataSource } from 'src/app/modules/shared/models/data-source.model';

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -62,27 +62,19 @@ Overwritten calendar style
   border: 0.1px solid lighten($primary-text, 30%);
 }
 
-@media (max-width: 576px) {
+@media (max-width: 640px) {
   div.dt-buttons {
     text-align: start !important;
   }
   .dataTables_wrapper .dataTables_filter {
     text-align: start !important;
-    margin-left: 40px;
   }
   div.dt-button-collection {
-    top: 50px !important;
+    position: fixed !important;
+    top: 250px !important;
     margin-left: 50px !important;
     overflow-y: scroll !important;
     max-height: 300px !important;
-  }
-}
-
-@media (min-width: 576px) {
-  div.dt-button-collection {
-    position: fixed !important;
-    top: 330px !important;
-    left: 280px !important;
     button.active:not(.disabled) {
     background: $primary !important;
     box-shadow: none !important;
@@ -90,12 +82,11 @@ Overwritten calendar style
   }
 }
 
-/* div.dt-button-collection {
-  position: fixed !important;
-  top: 330px !important;
-  margin-left: 280px !important;
-  overflow-y: scroll !important;
-  max-height: 300px !important;
+@media (min-width: 576px) {
+  div.dt-button-collection {
+    button.active:not(.disabled) {
+    background: $primary !important;
+    box-shadow: none !important;
+  }
+  }
 }
- */
-

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -61,3 +61,41 @@ Overwritten calendar style
 .cal-header .cal-cell {
   border: 0.1px solid lighten($primary-text, 30%);
 }
+
+@media (max-width: 576px) {
+  div.dt-buttons {
+    text-align: start !important;
+  }
+  .dataTables_wrapper .dataTables_filter {
+    text-align: start !important;
+    margin-left: 40px;
+  }
+  div.dt-button-collection {
+    top: 50px !important;
+    margin-left: 50px !important;
+    overflow-y: scroll !important;
+    max-height: 300px !important;
+  }
+}
+
+@media (min-width: 576px) {
+  div.dt-button-collection {
+    position: fixed !important;
+    top: 330px !important;
+    left: 280px !important;
+    button.active:not(.disabled) {
+    background: $primary !important;
+    box-shadow: none !important;
+  }
+  }
+}
+
+/* div.dt-button-collection {
+  position: fixed !important;
+  top: 330px !important;
+  margin-left: 280px !important;
+  overflow-y: scroll !important;
+  max-height: 300px !important;
+}
+ */
+


### PR DESCRIPTION
# Problem
In the Reports section, when we select the "Column visibility" button, this button shows a button row where each button represents a column name in the table.
This is working fine, but there is no notable difference between the selected buttons and no selected buttons inside this button row.

![column_visibility_before](https://user-images.githubusercontent.com/12177501/130882669-be96a480-f2b0-4aef-850a-87033415d28c.png)

Moreover, when there is a reduction in the screen size, the "Column visibility" button is not showing anything.

![column_visibility_screen_size_reduction](https://user-images.githubusercontent.com/12177501/130883232-b07e06a3-b03e-4070-ad1f-25d8b2d91233.png)

# Solution
In this pull request when we select the "Column visibility" button, we can see a clear difference between the selected buttons and no selected buttons by their color.

![column_visibility_after](https://user-images.githubusercontent.com/12177501/130883515-4ee58cd0-e266-412e-9256-8ed05f338cc0.png)

Also, when the screen size changes, the "Column visibility" button will display the button row as it normally does, adding a scroll in the y-axis.

![column_visibility_screen_size_after](https://user-images.githubusercontent.com/12177501/130883901-28e04b8e-d72a-4c37-b6e0-133d83ec0717.png)

**Note:**
**As a bonus, the print button functionality was improved, now it only prints the columns that are displayed in the table.**