### PR TITLE
fix: TT-328 when editing/creating entries set seconds to 0

### DIFF
--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -387,7 +387,7 @@ describe('TimeEntriesComponent', () => {
       uri: 'http://testing.is.fun',
       activity_id: 'sss',
       project_id: 'id',
-      start_date: new Date(),
+      start_date: new Date(new Date().setSeconds(0)),
       end_date: new Date(new Date().setHours(0, 0, 0, 0))
     };
     state.timeEntriesDataSource.data = [lastEntry];

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -385,7 +385,6 @@ describe('TimeEntriesComponent', () => {
     const currentDate = new Date();
     currentDate.setSeconds(defaultSeconds);
     currentDate.setMilliseconds(defaultSeconds);
-    const emptyDate = new Date(new Date().setHours(0, 0, 0, 0));
     const lastEntry = {
       description: 'testing is fun',
       technologies: [],
@@ -393,7 +392,7 @@ describe('TimeEntriesComponent', () => {
       activity_id: 'sss',
       project_id: 'id',
       start_date: currentDate,
-      end_date: emptyDate
+      end_date: currentDate
     };
     state.timeEntriesDataSource.data = [lastEntry];
     mockEntriesSelector = store.overrideSelector(getTimeEntriesDataSource, state.timeEntriesDataSource);

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -381,14 +381,18 @@ describe('TimeEntriesComponent', () => {
   it('should preload data of last entry when a project is selected while creating new entry ', waitForAsync(() => {
     component.entry = null;
     component.entryId = null;
+    const defaultSeconds = 0;
+    const currentDate = new Date();
+    currentDate.setSeconds(defaultSeconds);
+    const emptyDate = new Date(new Date().setHours(0, 0, 0, 0));
     const lastEntry = {
       description: 'testing is fun',
       technologies: [],
       uri: 'http://testing.is.fun',
       activity_id: 'sss',
       project_id: 'id',
-      start_date: new Date(new Date().setSeconds(0)),
-      end_date: new Date(new Date().setHours(0, 0, 0, 0))
+      start_date: currentDate,
+      end_date: emptyDate
     };
     state.timeEntriesDataSource.data = [lastEntry];
     mockEntriesSelector = store.overrideSelector(getTimeEntriesDataSource, state.timeEntriesDataSource);

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -384,6 +384,7 @@ describe('TimeEntriesComponent', () => {
     const defaultSeconds = 0;
     const currentDate = new Date();
     currentDate.setSeconds(defaultSeconds);
+    currentDate.setMilliseconds(defaultSeconds);
     const emptyDate = new Date(new Date().setHours(0, 0, 0, 0));
     const lastEntry = {
       description: 'testing is fun',

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -142,6 +142,7 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
         const defaultSeconds = 0;
         const currentDate = new Date();
         currentDate.setSeconds(defaultSeconds);
+        currentDate.setMilliseconds(defaultSeconds);
         const emptyDate = new Date(new Date().setHours(0, 0, 0, 0));
         const entry = {
           description: dataToUse.description ? dataToUse.description : '',

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -139,15 +139,18 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
     this.store.pipe(select(getTimeEntriesDataSource)).subscribe(ds => {
       const dataToUse = ds.data.find(item => item.project_id === event.projectId);
       if (dataToUse && this.isNewEntry()) {
-        const startDate = new Date(new Date().setHours(0, 0, 0, 0));
+        const defaultSeconds = 0;
+        const currentDate = new Date();
+        currentDate.setSeconds(defaultSeconds);
+        const emptyDate = new Date(new Date().setHours(0, 0, 0, 0));
         const entry = {
           description: dataToUse.description ? dataToUse.description : '',
           technologies: dataToUse.technologies ? dataToUse.technologies : [],
           uri: dataToUse.uri ? dataToUse.uri : '',
           activity_id: dataToUse.activity_id,
           project_id: dataToUse.project_id,
-          start_date: new Date(new Date().setSeconds(0)),
-          end_date: startDate
+          start_date: currentDate,
+          end_date: emptyDate
         };
         this.entry = entry;
       }

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -146,7 +146,7 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
           uri: dataToUse.uri ? dataToUse.uri : '',
           activity_id: dataToUse.activity_id,
           project_id: dataToUse.project_id,
-          start_date: new Date(),
+          start_date: new Date(new Date().setSeconds(0)),
           end_date: startDate
         };
         this.entry = entry;

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -143,7 +143,6 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
         const currentDate = new Date();
         currentDate.setSeconds(defaultSeconds);
         currentDate.setMilliseconds(defaultSeconds);
-        const emptyDate = new Date(new Date().setHours(0, 0, 0, 0));
         const entry = {
           description: dataToUse.description ? dataToUse.description : '',
           technologies: dataToUse.technologies ? dataToUse.technologies : [],
@@ -151,7 +150,7 @@ export class TimeEntriesComponent implements OnInit, OnDestroy {
           activity_id: dataToUse.activity_id,
           project_id: dataToUse.project_id,
           start_date: currentDate,
-          end_date: emptyDate
+          end_date: currentDate
         };
         this.entry = entry;
       }


### PR DESCRIPTION
With the modification of the lines of code of this pull request, each new time entry created from the "Time Entries" menu will have the following hour format established: "HH:mm:ss", where ss will always be set to 00 to avoid conflicts with inexistent time overlaps.