### PR TITLE
fix: TT-333 Fix functionality of Excel and CSV buttons

### DIFF
--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
@@ -21,27 +21,18 @@ export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewIn
     buttons: [
       {
         extend: 'colvis',
-        columns: ':not(.hidden-col),visible'
+        columns: ':not(.hidden-col)'
       },
       {
-        extend: 'print',
-        exportOptions: {
-          columns: ':visible'
-          }
+        extend: 'print'
       },
       {
         extend: 'excel',
-        exportOptions: {
-          columns: ':visible'
-        },
         text: 'Excel',
         filename: `time-entries-${formatDate(new Date(), 'MM_dd_yyyy-HH_mm', 'en')}`
       },
       {
         extend: 'csv',
-        exportOptions: {
-          columns: ':visible'
-        },
         text: 'CSV',
         filename: `time-entries-${formatDate(new Date(), 'MM_dd_yyyy-HH_mm', 'en')}`
       },


### PR DESCRIPTION
# Problem
Currently in the Reports section, when the CSV or Excel buttons are selected, these do not show the ID columns in the exported file.

![problem_with_ID_columns](https://user-images.githubusercontent.com/12177501/131815869-e5d5caf8-446c-43cc-8767-9473df8e7557.png)

# Solution

The previous functionality of the buttons was implemented.

![previos_functionality](https://user-images.githubusercontent.com/12177501/131816250-41a4eee6-b0a5-4a22-8659-32827cafe3eb.png)
