### PR TITLE
fix: TT-216 add tabIndex attribute to materialDatePicker and to Date …

### DIFF
--- a/src/app/modules/shared/components/details-fields/details-fields.component.html
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.html
@@ -80,7 +80,7 @@
 
       <div class="form-group row" >
         <label class="col-12 col-sm-2">Date in:</label>
-        <div class="col-12 col-sm-4">
+        <div class="col-12 col-sm-4" tabindex="0">
           <input
             matInput
             formControlName="start_date"
@@ -93,6 +93,7 @@
             (ngModelChange)="onStartDateChange($event)"
             [max]="getCurrentDate()"
             onkeydown="return false"
+            [tabIndex]="1"
             (click)="openOrCloseDatePicker(datepickerStartDate)"
             (dateInput)="start_date.setValue($event.value.format('YYYY-MM-DD'))"
             [matDatepicker]="datepickerStartDate"
@@ -115,7 +116,7 @@
 
       <div class="form-group row" *ngIf="!goingToWorkOnThis || !canMarkEntryAsWIP">
         <label class="col-12 col-sm-2">Date out:</label>
-        <div class="col-12 col-sm-4">
+        <div class="col-12 col-sm-4" tabindex="0">
           <input
             matInput
             formControlName="end_date"
@@ -127,6 +128,7 @@
             required
             [max]="getCurrentDate()"
             onkeydown="return false"
+            [tabIndex]="1"
             (click)="openOrCloseDatePicker(datepickerEndDate)"
             (dateInput)="end_date.setValue($event.value.format('YYYY-MM-DD'))"
             [matDatepicker]="datepickerEndDate"


### PR DESCRIPTION
## Problem

At the time-entries tab, when trying to create a new time entry (or modify existing one), and using the tab key to move between fields, when you’re in the date field, hitting the tab key doesn’t do anything and you have to use your mouse to select the next field. 

## Solution

The "tabIndex" was added to the materialDatePicker which is the tool used for date and time selection, this allows us to navigate through the entry using the tab key. However, it is necessary to notice that we will not be able to actually modify the date itself, just the time; this is caused because the component property works as such.