### PR TITLE
fix: TT-334 Keep the sidebar item selected when the page is refreshed

### DIFF
--- a/src/app/modules/shared/components/sidebar/sidebar.component.ts
+++ b/src/app/modules/shared/components/sidebar/sidebar.component.ts
@@ -26,12 +26,13 @@ export class SidebarComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.toggleSideBar();
-    this.sidebarItems$ = this.getSidebarItems().subscribe();
-    this.highlightMenuOption(this.router.routerState.snapshot.url);
+    const currentRouting = this.router.routerState.snapshot.url;
+    this.sidebarItems$ = this.getSidebarItems().subscribe(() => this.highlightMenuOption(currentRouting));
     this.navStart.subscribe((evt) => {
       this.highlightMenuOption(evt.url);
     });
   }
+
   ngOnDestroy(): void {
     this.sidebarItems$.unsubscribe();
   }


### PR DESCRIPTION
# Description
The project sidebar presents some elements, depending on the group to which the user belongs, and a style is applied to the element (option) when it is selected. However, when the page is reloaded, the selected option is not presented with the active style.

# Solution
When the page is reloaded, a comparison is made between the selected option and the route where it is located, to add the active style to the selected option in the sidebar.