### PR TITLE
fix: TT-336 Fix format Duration column

### DIFF
--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.spec.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.spec.ts
@@ -1,5 +1,4 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterLinkWithHref } from '@angular/router';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { Entry } from 'src/app/modules/shared/models';
 import { SubstractDatePipe } from 'src/app/modules/shared/pipes/substract-date/substract-date.pipe';

--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.spec.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.spec.ts
@@ -1,4 +1,5 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterLinkWithHref } from '@angular/router';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { Entry } from 'src/app/modules/shared/models';
 import { SubstractDatePipe } from 'src/app/modules/shared/pipes/substract-date/substract-date.pipe';
@@ -13,6 +14,9 @@ describe('Reports Page', () => {
     let store: MockStore<EntryState>;
     let getReportDataSourceSelectorMock;
     let durationTime: number;
+    let row: number;
+    let node: number;
+    let decimalValidator: RegExp;
     const timeEntry: Entry = {
       id: '123',
       start_date: new Date(),
@@ -65,6 +69,9 @@ describe('Reports Page', () => {
 
     beforeEach(() => {
       durationTime = new Date().setHours(5, 30);
+      row = 0;
+      node = 0;
+      decimalValidator = /^\d+\.\d{0,2}$/;
     });
 
     it('component should be created', async () => {
@@ -113,11 +120,14 @@ describe('Reports Page', () => {
     });
 
     it('The data should be displayed as a multiple of hour when column is equal to 3', () => {
-      expect(component.bodyExportOptions(durationTime, 0, 3, 0)).toMatch(/^\d+\.\d{0,2}$/);
+      const column = 3;
+
+      expect(component.bodyExportOptions(durationTime, row, column, node)).toMatch(decimalValidator);
     });
 
     it('The data should not be displayed as a multiple of hour when column is different of 3', () => {
-      expect(component.bodyExportOptions(durationTime, 0, 4, 0)).toBe(durationTime);
+      const column = 4;
+      expect(component.bodyExportOptions(durationTime, row, column, node)).toBe(durationTime);
     });
 
     afterEach(() => {

--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.spec.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.spec.ts
@@ -12,6 +12,7 @@ describe('Reports Page', () => {
     let fixture: ComponentFixture<TimeEntriesTableComponent>;
     let store: MockStore<EntryState>;
     let getReportDataSourceSelectorMock;
+    let durationTime: number;
     const timeEntry: Entry = {
       id: '123',
       start_date: new Date(),
@@ -62,6 +63,10 @@ describe('Reports Page', () => {
       })
     );
 
+    beforeEach(() => {
+      durationTime = new Date().setHours(5, 30);
+    });
+
     it('component should be created', async () => {
       expect(component).toBeTruthy();
     });
@@ -105,6 +110,14 @@ describe('Reports Page', () => {
 
       expect(component.isURL(param.url)).toEqual(param.expected_value);
       });
+    });
+
+    it('The data should be displayed as a multiple of hour when column is equal to 3', () => {
+      expect(component.bodyExportOptions(durationTime, 0, 3, 0)).toMatch(/^[+-]?([0-9]+\.?[0-9]*|\.[0-9]+)$/);
+    });
+
+    it('The data should not be displayed as a multiple of hour when column is different of 3', () => {
+      expect(component.bodyExportOptions(durationTime, 0, 4, 0)).toBe(durationTime);
     });
 
     afterEach(() => {

--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.spec.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.spec.ts
@@ -113,7 +113,7 @@ describe('Reports Page', () => {
     });
 
     it('The data should be displayed as a multiple of hour when column is equal to 3', () => {
-      expect(component.bodyExportOptions(durationTime, 0, 3, 0)).toMatch(/^[+-]?([0-9]+\.?[0-9]*|\.[0-9]+)$/);
+      expect(component.bodyExportOptions(durationTime, 0, 3, 0)).toMatch(/^\d+\.\d{0,2}$/);
     });
 
     it('The data should not be displayed as a multiple of hour when column is different of 3', () => {

--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
@@ -96,7 +96,6 @@ export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewIn
   }
 
   bodyExportOptions(data, row, column, node){
-    console.log(data);
     const durationColumnIndex = 3;
     return column === durationColumnIndex ? moment.duration(data).asHours().toFixed(2) : data;
   }

--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
@@ -31,11 +31,7 @@ export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewIn
         extend: 'excel',
         exportOptions: {
           format: {
-            body: (data, row, column, node) => {
-              return column === 3 ?
-              moment.duration(data).asHours().toFixed(4).slice(0, -1) :
-              data;
-            },
+            body: this.bodyExportOptions
           }
         },
         text: 'Excel',
@@ -45,11 +41,7 @@ export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewIn
         extend: 'csv',
         exportOptions: {
           format: {
-            body: (data, row, column, node) => {
-              return column === 3 ?
-              moment.duration(data).asHours().toFixed(4).slice(0, -1) :
-              data;
-            },
+            body: this.bodyExportOptions
           }
         },
         text: 'CSV',
@@ -101,5 +93,11 @@ export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewIn
   isURL(uri: string): boolean {
     const regex = new RegExp('http*', 'g');
     return regex.test(uri);
+  }
+
+  bodyExportOptions(data, row, column, node){
+    console.log(data);
+    const durationColumnIndex = 3;
+    return column === durationColumnIndex ? moment.duration(data).asHours().toFixed(2) : data;
   }
 }

--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
@@ -2,6 +2,7 @@ import { formatDate } from '@angular/common';
 import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import { select, Store } from '@ngrx/store';
 import { DataTableDirective } from 'angular-datatables';
+import * as moment from 'moment';
 import { Observable, Subject, Subscription } from 'rxjs';
 import { Entry } from 'src/app/modules/shared/models';
 import { DataSource } from 'src/app/modules/shared/models/data-source.model';
@@ -28,11 +29,29 @@ export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewIn
       },
       {
         extend: 'excel',
+        exportOptions: {
+          format: {
+            body: (data, row, column, node) => {
+              return column === 3 ?
+              moment.duration(data).asHours().toFixed(4).slice(0, -1) :
+              data;
+            },
+          }
+        },
         text: 'Excel',
         filename: `time-entries-${formatDate(new Date(), 'MM_dd_yyyy-HH_mm', 'en')}`
       },
       {
         extend: 'csv',
+        exportOptions: {
+          format: {
+            body: (data, row, column, node) => {
+              return column === 3 ?
+              moment.duration(data).asHours().toFixed(4).slice(0, -1) :
+              data;
+            },
+          }
+        },
         text: 'CSV',
         filename: `time-entries-${formatDate(new Date(), 'MM_dd_yyyy-HH_mm', 'en')}`
       },


### PR DESCRIPTION
# Problem
The Duration column format inside the Reports section is not correct. This format is presenting the data in hours and minutes.

![wrong_duration_format](https://user-images.githubusercontent.com/12177501/132756708-c6ec044c-e9d5-41e0-8961-2514a6b88d98.jpeg)

# Solution
This pull request retrieves the previous format of the Duration column. This format displays the data in hours or multiples of hours.

![correct_duration_format](https://user-images.githubusercontent.com/12177501/132756382-2e77e97a-3a92-4fa3-9ae6-27999cc7a38d.png)

