### PR TITLE
fix: TT-340 remove unwanted space at the bottom of the UI

### DIFF
--- a/src/app/modules/shared/components/sidebar/sidebar.component.scss
+++ b/src/app/modules/shared/components/sidebar/sidebar.component.scss
@@ -60,7 +60,7 @@ body {
 
 .content_app {
   padding: 2rem 3rem 5rem 3rem;
-  overflow-y: auto;
+  overflow-y: scroll;
 }
 
 .active {
@@ -72,8 +72,8 @@ body {
 
 .full-height {
   height: 100%;
-  height: -moz-calc(100vh - 12vh);
-  height: -webkit-calc(100vh - 12vh);
-  height: -o-calc(100vh - 12vh);
-  height: calc(100vh - 12vh);
+  height: -moz-calc(100vh - 1vh);
+  height: -webkit-calc(100vh - 1vh);
+  height: -o-calc(100vh - 1vh);
+  height: calc(100vh - 1vh);
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -17,6 +17,7 @@ body {
   margin: 0;
   padding: 0;
   overflow-x: hidden;
+  overflow-y: hidden;
 }
 
 .table.dataTable th,


### PR DESCRIPTION
###  Problem

At the moment, the UI does not allow us to use the whole screen, there is a problem at the bottom of the page, so we have content shrinked, as in the following picture:

[![](https://i.postimg.cc/B6TbKTrR/Screenshot-from-2021-09-16-17-32-10.png)](https://i.postimg.cc/B6TbKTrR/Screenshot-from-2021-09-16-17-32-10.png)

### Solution

Styling files were modified, so we can have an improved user experience in the UI. The result is as in the following picture, where you can see that the content is using the whole screen now:

[![](https://i.postimg.cc/5yf0qH1y/Screenshot-from-2021-09-16-17-33-32.png)](https://i.postimg.cc/5yf0qH1y/Screenshot-from-2021-09-16-17-33-32.png)