### PR TITLE
feat: TT-337 "Add new activity button" implementation

### DIFF
--- a/src/app/modules/activities-management/components/activity-list/activity-list.component.ts
+++ b/src/app/modules/activities-management/components/activity-list/activity-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { select, Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { delay, map } from 'rxjs/operators';
@@ -14,6 +14,9 @@ import { ActivityState } from './../../store/activity-management.reducers';
   styleUrls: ['./activity-list.component.scss'],
 })
 export class ActivityListComponent implements OnInit {
+  @Input() showActivityForm: boolean;
+  @Output() changeValueShowActivityForm = new EventEmitter<boolean>();
+
   constructor(private store: Store<ActivityState>) {
     this.isLoading$ = store.pipe(delay(0), select(getIsLoading));
   }
@@ -66,6 +69,7 @@ export class ActivityListComponent implements OnInit {
 
   updateActivity(activityId: string): void {
     this.store.dispatch(new SetActivityToEdit(activityId));
+    this.changeValueShowActivityForm.emit(this.showActivityForm = true);
   }
 
   unarchiveActivity(): void {

--- a/src/app/modules/activities-management/components/create-activity/create-activity.component.html
+++ b/src/app/modules/activities-management/components/create-activity/create-activity.component.html
@@ -21,7 +21,7 @@
 
     <div class="form-group" style="text-align: right;">
       <button class="btn btn-primary" type="submit" [disabled]="!activityForm.valid">Save</button>
-      <button class="btn btn-secondary mb-2 ml-2 mt-2" type="reset" [hidden]="!activityToEdit" (click)="cancelButton()">
+      <button class="btn btn-secondary mb-2 ml-2 mt-2" type="button" (click)="cancelButton()">
         Cancel
       </button>
     </div>

--- a/src/app/modules/activities-management/components/create-activity/create-activity.component.ts
+++ b/src/app/modules/activities-management/components/create-activity/create-activity.component.ts
@@ -1,7 +1,6 @@
 import { FormBuilder, Validators, FormGroup } from '@angular/forms';
-import { Component, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Store, select } from '@ngrx/store';
-
 import { Activity } from '../../../shared/models';
 import { ActivityState } from './../../store/activity-management.reducers';
 import { CreateActivity, UpdateActivity, getActivityById, ResetActivityToEdit } from '../../store';
@@ -12,9 +11,9 @@ import { CreateActivity, UpdateActivity, getActivityById, ResetActivityToEdit } 
   styleUrls: ['./create-activity.component.scss'],
 })
 export class CreateActivityComponent implements OnInit {
+  @Output() closeActivityForm = new EventEmitter<boolean>();
   activityForm: FormGroup;
   activityToEdit: Activity;
-
   constructor(private formBuilder: FormBuilder, private store: Store<ActivityState>) {
     this.activityForm = this.formBuilder.group({
       name: ['', Validators.required],
@@ -60,9 +59,12 @@ export class CreateActivityComponent implements OnInit {
       this.store.dispatch(new CreateActivity(activityData));
       this.activityForm.get('description').setValue('');
     }
+    this.closeActivityForm.emit(false);
   }
 
   cancelButton() {
+    this.activityForm.reset();
     this.store.dispatch(new ResetActivityToEdit());
+    this.closeActivityForm.emit(false);
   }
 }

--- a/src/app/modules/activities-management/pages/activities-management.component.html
+++ b/src/app/modules/activities-management/pages/activities-management.component.html
@@ -1,4 +1,13 @@
 <div class="col-12 col-md-9 px-0">
-  <app-create-activity></app-create-activity>
-  <app-activity-list></app-activity-list>
+  <div class="row">
+    <div style="padding: 15px;">
+      <button (click)="activateActivityForm()" class="btn btn-primary">Add new Activity</button>
+    </div>
+  </div>
+  <div *ngIf="showActivityForm">
+    <app-create-activity
+    (closeActivityForm)="closeFormActivity($event)"></app-create-activity>
+  </div>
+  <app-activity-list
+  (changeValueShowActivityForm)="showActivityForm = $event"></app-activity-list>
 </div>

--- a/src/app/modules/activities-management/pages/activities-management.component.spec.ts
+++ b/src/app/modules/activities-management/pages/activities-management.component.spec.ts
@@ -1,14 +1,19 @@
 import { waitForAsync, TestBed, ComponentFixture } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { ActivitiesManagementComponent } from './activities-management.component';
+import { SetActivityToEdit } from '../store';
+import { Activity } from '../../shared/models';
 
 describe('ActivitiesManagementComponent', () => {
   let component: ActivitiesManagementComponent;
   let fixture: ComponentFixture<ActivitiesManagementComponent>;
+  let store: MockStore<Activity>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [],
-      declarations: [ActivitiesManagementComponent]
+      declarations: [ActivitiesManagementComponent],
+      providers: [provideMockStore({ initialState: {} })],
     }).compileComponents();
   }));
 
@@ -16,9 +21,26 @@ describe('ActivitiesManagementComponent', () => {
     fixture = TestBed.createComponent(ActivitiesManagementComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    store = TestBed.inject(MockStore);
   });
 
   it('should create the component', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should dispatch an action on activateActivityForm', () => {
+    spyOn(store, 'dispatch');
+
+    component.activateActivityForm();
+
+    expect(store.dispatch).toHaveBeenCalledWith(new SetActivityToEdit(null));
+  });
+
+  it('should call closeActivityForm function', () => {
+    component.closeFormActivity(false);
+
+    expect(component.showActivityForm).toBe(false);
+  });
+
+
 });

--- a/src/app/modules/activities-management/pages/activities-management.component.ts
+++ b/src/app/modules/activities-management/pages/activities-management.component.ts
@@ -1,4 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, EventEmitter, Output } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { Activity } from '../../shared/models';
+import { SetActivityToEdit } from '../store';
 
 @Component({
   selector: 'app-activities-management',
@@ -6,5 +9,19 @@ import { Component } from '@angular/core';
   styleUrls: ['./activities-management.component.scss'],
 })
 export class ActivitiesManagementComponent {
-  constructor() {}
+  @Output() sendChanges = new EventEmitter<boolean>();
+  @Output() closeActivityForm = new EventEmitter<boolean>();
+  showActivityForm = false;
+  hasChangeComponent = false;
+  hasChanged: boolean;
+  constructor(private store: Store<Activity>) {}
+
+  activateActivityForm() {
+    this.store.dispatch(new SetActivityToEdit(null));
+    this.showActivityForm === false ? this.showActivityForm = true : this.showActivityForm = false;
+  }
+
+  closeFormActivity(event) {
+    this.showActivityForm = event;
+  }
 }


### PR DESCRIPTION
# Problem
When the Activities section is selected, the option to create a new activity or to edit an activity is always present:

![activities-section-before](https://user-images.githubusercontent.com/12177501/134091228-b49949f9-a9d0-4021-bc51-10b5f3e135b9.jpeg)

# Solution
In this pull request, the form to add or edit activity is hidden by default.

A button to "Add a new activity" has been created. When this button is clicked, the form to add a new activity appears:

![new-button](https://user-images.githubusercontent.com/12177501/134089675-134ab07d-0e79-44bd-a426-a2c4277289af.jpeg)

The same occurs when the edit activity button is clicked:

![edit-button-now](https://user-images.githubusercontent.com/12177501/134090536-710eb223-451a-41d3-b45d-89262e081d96.jpeg)

