### PR TITLE
TT-382 Changes in report datatable

### DIFF
--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
@@ -15,11 +15,13 @@ import { getReportDataSource } from '../../../time-clock/store/entry.selectors';
   styleUrls: ['./time-entries-table.component.scss'],
 })
 export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewInit {
+  selectOptionValues = [15, 30, 50, 100, -1];
+  selectOptionNames = [15, 30, 50, 100, 'All'];
   dtOptions: any = {
     scrollY: '590px',
     dom: '<"d-flex justify-content-between"B<"d-flex"<"mr-5"l>f>>rtip',
     pageLength: 30,
-    lengthMenu: [[15, 30, 50, 100, -1], [15, 30, 50, 100, 'All']],
+    lengthMenu: [this.selectOptionValues, this.selectOptionNames],
     buttons: [
       {
         extend: 'colvis',


### PR DESCRIPTION
In this PR the default range of records has been changed from 10 to 30 reports, and the option to select a certain range of records has been added. This option has a range of 15, 30, 50, 100 or all records.

![Captura de Pantalla 2021-10-19 a la(s) 12 56 57](https://user-images.githubusercontent.com/23491092/137969217-0df9682d-0114-4f5a-add0-df41d690d862.png)
![Captura de Pantalla 2021-10-19 a la(s) 13 28 38](https://user-images.githubusercontent.com/23491092/137969472-32028cba-305b-4288-b9bd-9e1ba1c9685b.png)


