### PR TITLE
fix: TT-392 format correct to column Time and export reports exclude tags < />

### DIFF
--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.spec.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.spec.ts
@@ -120,14 +120,20 @@ describe('Reports Page', () => {
 
     it('The data should be displayed as a multiple of hour when column is equal to 3', () => {
       const column = 3;
-
       expect(component.bodyExportOptions(durationTime, row, column, node)).toMatch(decimalValidator);
     });
 
     it('The data should not be displayed as a multiple of hour when column is different of 3', () => {
       const column = 4;
-      expect(component.bodyExportOptions(durationTime, row, column, node)).toBe(durationTime);
+      expect(component.bodyExportOptions(durationTime, row, column, node)).toBe(durationTime.toString());
     });
+
+    it('The link Ticket must not contain the ticket URL enclosed with < > when export a file csv, excel or PDF', () => {
+      const entry = '<a _ngcontent-vlm-c151="" class="is-url">https://TT-392-uri</a>';
+      const column = 0;
+      expect(component.bodyExportOptions(entry, row, column, node)).toBe('https://TT-392-uri');
+    });
+
 
     afterEach(() => {
       fixture.destroy();

--- a/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
+++ b/src/app/modules/reports/components/time-entries-table/time-entries-table.component.ts
@@ -99,7 +99,9 @@ export class TimeEntriesTableComponent implements OnInit, OnDestroy, AfterViewIn
   }
 
   bodyExportOptions(data, row, column, node){
+    const dataFormated = data.toString().replace(/<((.|\n){0,200}?)>/gi, '');
     const durationColumnIndex = 3;
-    return column === durationColumnIndex ? moment.duration(data).asHours().toFixed(2) : data;
+    return column === durationColumnIndex ? moment.duration(dataFormated).asHours().toFixed(2) : dataFormated;
   }
 }
+


### PR DESCRIPTION
**Objetive:**
Exclude from reports this tags in the Ticket column
```
<a_ngcontent-vlm-c151=' class="is-url"> https://ioetec.atlassian.net/k
"ng-reflect-ng-if": "true"
1->
```
![image](https://user-images.githubusercontent.com/12575632/140200902-56624d2a-c61f-495b-8ceb-a04b3489f2a3.png)

The problem is solved by removing these tags with a regular expression.
With the solution it looks like this:

<img width="777" alt="Screen Shot 2021-11-03 at 17 04 18" src="https://user-images.githubusercontent.com/12575632/140201104-3dd9b073-7f99-4b73-b366-6c01b6fdbe51.png">



