### PR TITLE
fix: TT-413 show projects when you do not have the latest projects

### DIFF
--- a/src/app/modules/shared/components/details-fields/details-fields.component.ts
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.ts
@@ -161,17 +161,17 @@ export class DetailsFieldsComponent implements OnChanges, OnInit {
     this.store.dispatch(new projectActions.LoadProjects());
     const recentProjects$ = this.store.pipe(select(getRecentProjects));
     recentProjects$.subscribe((projects) => {
-      if (projects) {
-        this.listRecentProjects = [];
+      this.listRecentProjects = [];
+      if (projects?.length > 0) {
         projects.forEach((project) => {
           const projectWithSearchField = { ...project };
           projectWithSearchField.search_field = `${project.customer.name} - ${project.name}`;
           this.listRecentProjects.push(projectWithSearchField);
         });
-        this.listProjectsShowed = this.listRecentProjects;
       }else{
         this.listRecentProjects = this.listProjects;
       }
+      this.listProjectsShowed = this.listRecentProjects;
     });
   }
 

--- a/src/app/modules/shared/components/technologies/technologies.component.ts
+++ b/src/app/modules/shared/components/technologies/technologies.component.ts
@@ -17,7 +17,7 @@ export class TechnologiesComponent implements OnInit, OnDestroy {
   readonly ALLOW_SELECT_MULTIPLE = true;
   readonly ALLOW_SEARCH = true;
   readonly MIN_SEARCH_TERM_LENGTH = 2;
-  readonly TYPE_TO_SEARCH_TEXT = 'Please enter 2 or more characters';
+  readonly TYPE_TO_SEARCH_TEXT = 'Please enter 2 or more characters to search for technologies ';
   readonly WAITING_TIME_AFTER_KEY_UP = 400;
 
   isLoading = false;

--- a/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
+++ b/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
@@ -73,10 +73,10 @@ export class ProjectListHoverComponent implements OnInit, OnDestroy {
     this.recentProjectsSubscription = recentProjects$.subscribe((projects) => {
       if (projects) {
         this.listRecentProjects = projects;
-        this.listProjectsShowed = this.listRecentProjects;
       }else{
         this.listRecentProjects = this.listProjects;
       }
+      this.listProjectsShowed = this.listRecentProjects;
     });
 
     this.updateEntrySubscription = this.actionsSubject$

--- a/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
+++ b/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
@@ -71,7 +71,7 @@ export class ProjectListHoverComponent implements OnInit, OnDestroy {
     this.store.dispatch(new actions.LoadProjects());
     const recentProjects$ = this.store.pipe(select(getRecentProjects));
     this.recentProjectsSubscription = recentProjects$.subscribe((projects) => {
-      if (projects) {
+      if (projects?.length > 0) {
         this.listRecentProjects = projects;
       }else{
         this.listRecentProjects = this.listProjects;


### PR DESCRIPTION
**Problem**
Whenever a user enters in the Time Clock>Projects, they have to type in a project for the feature to show a message.

![image](https://user-images.githubusercontent.com/37599693/144449351-468e165c-1fd6-4c2b-b354-e0a3c8a3edde.png)

the message of the technologies is not clear and new users do not understand how it works
![image](https://user-images.githubusercontent.com/37599693/144449626-c52c72e0-6eca-416b-b8b5-ac128178b4db.png)

**Solution**
when it is a new user, all available projects are displayed and when it is an old user, only the old projects are displayed.

![image](https://user-images.githubusercontent.com/37599693/144455261-7dc0c653-d20d-4bbc-80a4-dea9a8b277bc.png)

improved help text of technologi
![image](https://user-images.githubusercontent.com/37599693/144456054-48f43e22-253e-4952-a645-b60dda2ed339.png)

