### PR TITLE
fix: TT-437 validated maximum time entry hours

### DIFF
--- a/src/app/modules/shared/components/details-fields/details-fields.component.html
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.html
@@ -117,6 +117,7 @@
             class="form-control"
             aria-label="Small"
             aria-describedby="inputGroup-sizing-sm"
+            [disabled]="true"
             [class.is-invalid]="end_date.invalid && end_date.touched"
             required
             [max]="getCurrentDate()"

--- a/src/app/modules/shared/components/details-fields/details-fields.component.ts
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.ts
@@ -383,6 +383,7 @@ export class DetailsFieldsComponent implements OnChanges, OnInit {
         end_date: formatDate(get(this.entryToEdit, 'start_date', ''), DATE_FORMAT, 'en'),
         end_hour: formatDate(new Date(), 'HH:mm', 'en'),
       });
+      this.end_date.setValue(this.start_date.value);
     }
     this.shouldRestartEntry = !this.entryToEdit?.running && this.goingToWorkOnThis;
   }


### PR DESCRIPTION
**Problem**
Whenever a user records a time entry, user has to record the date in and date out.
![image](https://user-images.githubusercontent.com/37599693/144646414-bc258115-dd5e-4b3f-850b-515355cf408c.png)

**Solution**
when the user enters a new time entry he can only enter the entry date and the exit date will be updated automatically.
![image](https://user-images.githubusercontent.com/37599693/144646694-1613f261-a431-461d-b8e8-f20de0761427.png)
![image](https://user-images.githubusercontent.com/37599693/144646715-4bcb2103-cf20-45eb-a438-1e037e8536c8.png)

