### PR TITLE
fix: TT-483 consume new endpoint from be v2

### DIFF
--- a/src/app/modules/users/components/users-list/users-list.component.html
+++ b/src/app/modules/users/components/users-list/users-list.component.html
@@ -20,7 +20,7 @@
         <td class="col-3 text-center">
           <ui-switch
             size="small"
-            (change)="switchGroup('time-tracker-admin', user); updateRole(ROLES.admin, user, $event);"
+            (change)="!isDevelopment?switchGroup('time-tracker-admin', user):null; updateRole(ROLES.admin, user, $event);"
             [checked]="user.groups.includes('time-tracker-admin')"></ui-switch>
           admin
           <span *ngIf="!isDevelopment">

--- a/src/app/modules/users/services/users.service.spec.ts
+++ b/src/app/modules/users/services/users.service.spec.ts
@@ -35,6 +35,7 @@ describe('UsersService', () => {
   it('grant role to a User', () => {
     const userId = 'userId';
     const roleId = 'admin';
+    service.isProduction = true;
 
     service.grantRole(userId, roleId).subscribe();
 
@@ -42,13 +43,36 @@ describe('UsersService', () => {
     expect(grantRoleRequest.request.method).toBe('POST');
   });
 
+  it('grant role to a User locally', () => {
+    const userId = 'userId';
+    const roleId = 'admin';
+    service.isProduction = false;
+
+    service.grantRole(userId, roleId).subscribe();
+
+    const grantRoleRequest = httpMock.expectOne(`${service.baseUrl}/${userId}/${roleId}/grant`);
+    expect(grantRoleRequest.request.method).toBe('POST');
+  });
+
   it('revoke role to a User', () => {
     const userId = 'userId';
     const roleId = 'admin';
+    service.isProduction = true;
 
     service.revokeRole(userId, roleId).subscribe();
 
     const grantRoleRequest = httpMock.expectOne(`${service.baseUrl}/${userId}/roles/${roleId}/revoke`);
+    expect(grantRoleRequest.request.method).toBe('POST');
+  });
+
+  it('revoke role to a User locally', () => {
+    const userId = 'userId';
+    const roleId = 'admin';
+    service.isProduction = false;
+
+    service.revokeRole(userId, roleId).subscribe();
+
+    const grantRoleRequest = httpMock.expectOne(`${service.baseUrl}/${userId}/${roleId}/revoke`);
     expect(grantRoleRequest.request.method).toBe('POST');
   });
 

--- a/src/app/modules/users/services/users.service.ts
+++ b/src/app/modules/users/services/users.service.ts
@@ -7,6 +7,7 @@ import { environment } from './../../../../environments/environment';
   providedIn: 'root',
 })
 export class UsersService {
+  isProduction = environment.production;
   constructor(private http: HttpClient) {}
 
   baseUrl = `${environment.timeTrackerApiUrl}/users`;
@@ -16,12 +17,14 @@ export class UsersService {
   }
 
   grantRole(userId: string, roleId: string): Observable<any> {
-    const url = `${this.baseUrl}/${userId}/roles/${roleId}/grant`;
+    const url = this.isProduction ? `${this.baseUrl}/${userId}/roles/${roleId}/grant`
+    : `${this.baseUrl}/${userId}/${roleId}/grant`;
     return this.http.post(url, null);
   }
 
   revokeRole(userId: string, roleId: string): Observable<any> {
-    const url = `${this.baseUrl}/${userId}/roles/${roleId}/revoke`;
+    const url = this.isProduction ? `${this.baseUrl}/${userId}/roles/${roleId}/revoke`
+    : `${this.baseUrl}/${userId}/${roleId}/revoke`;
     return this.http.post(url, null);
   }
 


### PR DESCRIPTION
Routes for granting and revoking admin role to users were changed in order to consume the new endpoints from the backend v2. The switch button is working now.
![image](https://user-images.githubusercontent.com/46400773/147705729-7b41b605-3860-411e-b392-1b916b81a229.png)
