### PR TITLE
fix: TT-482 input Date out change disable to false

### DIFF
--- a/src/app/modules/shared/components/details-fields/details-fields.component.html
+++ b/src/app/modules/shared/components/details-fields/details-fields.component.html
@@ -117,7 +117,7 @@
             class="form-control"
             aria-label="Small"
             aria-describedby="inputGroup-sizing-sm"
-            [disabled]="true"
+            [disabled]="false"
             [class.is-invalid]="end_date.invalid && end_date.touched"
             required
             [max]="getCurrentDate()"


### PR DESCRIPTION
Enter the output date change disabled to false, this is the original value we used before. 
- If the data_out is higher or lower we have a validation to avoid adding incorrect dates.
- The Auzure function automatic_clock_out is working, I tried this function last three days.