### PR TITLE
fix: TT-508 update endpoints in the UI

### DIFF
--- a/src/app/modules/activities-management/services/activity.service.spec.ts
+++ b/src/app/modules/activities-management/services/activity.service.spec.ts
@@ -56,7 +56,7 @@ describe('Activity Service', () => {
   });
 
   it('activities are delete using DELETE from baseUrl', () => {
-    const url = `${service.baseUrl}/1`;
+    const url = `${service.baseUrl}/id:1`;
     service.deleteActivity(activities[0].id).subscribe((activitiesInResponse) => {
       expect(activitiesInResponse.filter((activity) => activity.id !== activities[0].id)).toEqual([activities[1]]);
     });
@@ -73,7 +73,7 @@ describe('Activity Service', () => {
     service.updateActivity(activity).subscribe((response) => {
       expect(response.name).toBe('aaa');
     });
-    const updateActivitiesRequest = httpMock.expectOne(`${service.baseUrl}/${activity.id}`);
+    const updateActivitiesRequest = httpMock.expectOne(`${service.baseUrl}/id:${activity.id}`);
     expect(updateActivitiesRequest.request.method).toBe('PUT');
     updateActivitiesRequest.flush(activity);
   });

--- a/src/app/modules/activities-management/services/activity.service.ts
+++ b/src/app/modules/activities-management/services/activity.service.ts
@@ -27,12 +27,12 @@ export class ActivityService {
   }
 
   deleteActivity(acitivityId: string): Observable<any> {
-    const url = `${this.baseUrl}/${acitivityId}`;
+    const url = `${this.baseUrl}/id:${acitivityId}`;
     return this.http.delete(url);
   }
 
   updateActivity(activityData): Observable<any> {
-    const url = `${this.baseUrl}/${activityData.id}`;
+    const url = `${this.baseUrl}/id:${activityData.id}`;
 
     const body = {
       ...activityData,

--- a/src/app/modules/customer-management/components/projects-type/services/project-type.service.spec.ts
+++ b/src/app/modules/customer-management/components/projects-type/services/project-type.service.spec.ts
@@ -56,7 +56,7 @@ describe('Activity Service', () => {
   });
 
   it('ProjectTypes are delete using DELETE from baseUrl', () => {
-    const url = `${service.baseUrl}/1`;
+    const url = `${service.baseUrl}/id:1`;
     service.deleteProjectType(projectTypes[0].id).subscribe((projectTypesInResponse) => {
       expect(projectTypesInResponse.filter((activity) => activity.id !== projectTypes[0].id)).toEqual([
         projectTypes[1],
@@ -70,12 +70,12 @@ describe('Activity Service', () => {
   it('update activity using PUT from baseUrl', () => {
     const projectType = { id: '1', name: 'aaa', description: 'bbb' };
 
-    service.baseUrl = 'project-type' + '/' + projectType.id;
+    service.baseUrl = 'project-type' + '/id:' + projectType.id;
 
     service.updateProjectType(projectType).subscribe((response) => {
       expect(response.name).toBe('aaa');
     });
-    const updateProjectTypeRequest = httpMock.expectOne(`${service.baseUrl}/${projectType.id}`);
+    const updateProjectTypeRequest = httpMock.expectOne(`${service.baseUrl}/id:${projectType.id}`);
     expect(updateProjectTypeRequest.request.method).toBe('PUT');
     updateProjectTypeRequest.flush(projectType);
   });

--- a/src/app/modules/customer-management/components/projects-type/services/project-type.service.ts
+++ b/src/app/modules/customer-management/components/projects-type/services/project-type.service.ts
@@ -23,12 +23,12 @@ export class ProjectTypeService {
   }
 
   deleteProjectType(projectTypeId: string): Observable<any> {
-    const url = `${this.baseUrl}/${projectTypeId}`;
+    const url = `${this.baseUrl}/id:${projectTypeId}`;
     return this.http.delete(url);
   }
 
   updateProjectType(projectTypeData): Observable<any> {
-    const url = `${this.baseUrl}/${projectTypeData.id}`;
+    const url = `${this.baseUrl}/id:${projectTypeData.id}`;
     return this.http.put(url, projectTypeData);
   }
 }

--- a/src/app/modules/customer-management/components/projects/components/services/project.service.spec.ts
+++ b/src/app/modules/customer-management/components/projects/components/services/project.service.spec.ts
@@ -86,7 +86,7 @@ describe('ProjectService', () => {
     service.updateProject(project).subscribe((response) => {
       expect(response.name).toBe('new name');
     });
-    const updateProjectRequest = httpMock.expectOne(`${service.url}/${project.id}`);
+    const updateProjectRequest = httpMock.expectOne(`${service.url}/id:${project.id}`);
     expect(updateProjectRequest.request.method).toBe('PUT');
     updateProjectRequest.flush(project);
   });
@@ -98,7 +98,7 @@ describe('ProjectService', () => {
     service.updateProject(project).subscribe((response) => {
       expect(response.name).toBe('new name');
     });
-    const updateProjectRequest = httpMock.expectOne(`${service.url}/${project.id}`);
+    const updateProjectRequest = httpMock.expectOne(`${service.url}/id:${project.id}`);
     expect(updateProjectRequest.request.method).toBe('PUT');
     updateProjectRequest.flush(project);
   });
@@ -115,7 +115,7 @@ describe('ProjectService', () => {
   });
 
   it('update status project using PUT from baseUrl locally', () => {
-    const url = `${service.url}/1`;
+    const url = `${service.url}/id:1`;
     service.isDevelopment = true;
     service.deleteProject(projectsList[0].id).subscribe((projectsInResponse) => {
       expect(projectsInResponse.filter((project) => project.id !== projectsList[0].id).length).toEqual(2);

--- a/src/app/modules/customer-management/components/projects/components/services/project.service.ts
+++ b/src/app/modules/customer-management/components/projects/components/services/project.service.ts
@@ -38,12 +38,12 @@ export class ProjectService {
         projectData.status = 1;
       }
     }
-    return this.http.put(`${this.url}/${id}`, projectData);
+    return this.http.put(`${this.url}/id:${id}`, projectData);
   }
 
   deleteProject(projectId: string): Observable<any> {
     return this.isDevelopment
-      ? this.http.put(`${this.url}/${projectId}`, { status: 0 })
+      ? this.http.put(`${this.url}/id:${projectId}`, { status: 0 })
       : this.http.delete(`${this.url}/${projectId}`);
   }
 }

--- a/src/app/modules/customer-management/services/customer.service.spec.ts
+++ b/src/app/modules/customer-management/services/customer.service.spec.ts
@@ -45,7 +45,7 @@ describe('CustomerService', () => {
       { name: 'aa', description: 'bb', tenant_id: 'cc', id: '1' },
       { name: 'xx', description: 'yy', tenant_id: 'zz', id: '2' },
     ];
-    const url = `${service.baseUrl}/1`;
+    const url = `${service.baseUrl}/id:1`;
     service.deleteCustomer(customer[0].id).subscribe();
     const getCustomerRequest = httpMock.expectOne(url);
 
@@ -55,13 +55,13 @@ describe('CustomerService', () => {
 
   it('update customer using PUT from baseUrl', () => {
     const customer = { id: '1', name: 'aaa', description: 'bbb' };
-    service.baseUrl = 'customers' + '/' + customer.id;
+    service.baseUrl = 'customers' + '/id:' + customer.id;
 
     service.updateCustomer(customer).subscribe((response) => {
       expect(response.name).toBe('aaa');
     });
 
-    const updateCustomerRequest = httpMock.expectOne(`${service.baseUrl}/${customer.id}`);
+    const updateCustomerRequest = httpMock.expectOne(`${service.baseUrl}/id:${customer.id}`);
 
     expect(updateCustomerRequest.request.method).toBe('PUT');
     updateCustomerRequest.flush(customer);

--- a/src/app/modules/customer-management/services/customer.service.ts
+++ b/src/app/modules/customer-management/services/customer.service.ts
@@ -21,12 +21,12 @@ export class CustomerService {
   }
 
   deleteCustomer(customerId: string): Observable<any> {
-    const url = `${this.baseUrl}/${customerId}`;
+    const url = `${this.baseUrl}/id:${customerId}`;
     return this.http.delete(url);
   }
 
   updateCustomer(customerData): Observable<any> {
-    const url = `${this.baseUrl}/${customerData.id}`;
+    const url = `${this.baseUrl}/id:${customerData.id}`;
     return this.http.put(url, customerData);
   }
 }

--- a/src/app/modules/time-clock/services/entry.service.spec.ts
+++ b/src/app/modules/time-clock/services/entry.service.spec.ts
@@ -70,7 +70,7 @@ describe('EntryService', () => {
 
     service.updateEntry(updatedEntry).subscribe();
 
-    const updateEntryRequest = httpMock.expectOne(`${service.baseUrl}/id`);
+    const updateEntryRequest = httpMock.expectOne(`${service.baseUrl}/id:id`);
     expect(updateEntryRequest.request.method).toBe('PUT');
   });
 
@@ -79,7 +79,7 @@ describe('EntryService', () => {
 
     service.deleteEntry(entry).subscribe();
 
-    const updateEntryRequest = httpMock.expectOne(`${service.baseUrl}/${entry}`);
+    const updateEntryRequest = httpMock.expectOne(`${service.baseUrl}/id:${entry}`);
     expect(updateEntryRequest.request.method).toBe('DELETE');
   });
 

--- a/src/app/modules/time-clock/services/entry.service.ts
+++ b/src/app/modules/time-clock/services/entry.service.ts
@@ -36,11 +36,11 @@ export class EntryService {
 
   updateEntry(entryData): Observable<any> {
     const {id} = entryData;
-    return this.http.put(`${this.baseUrl}/${id}`, entryData);
+    return this.http.put(`${this.baseUrl}/id:${id}`, entryData);
   }
 
   deleteEntry(entryId: string): Observable<any> {
-    const url = `${this.baseUrl}/${entryId}`;
+    const url = `${this.baseUrl}/id:${entryId}`;
     return this.http.delete(url);
   }
 


### PR DESCRIPTION
The task TT-484 have changes to resolve problems with the Serverless routes and is necessary update in the UI end points with the param ID.

List of services to update in the UI
deleteActivity.
updateActivity
updateProject
deleteProject
deleteProjectType
updateProjectType
deleteCustomer
updateCustomer
updateEntry
deleteEntry