### PR TITLE
fix: TTA 183 get summary returns 404 at begginning of the month

### DIFF
--- a/src/app/modules/time-clock/store/entry.effects.ts
+++ b/src/app/modules/time-clock/store/entry.effects.ts
@@ -45,6 +45,9 @@ export class EntryEffects {
     mergeMap(() =>
       this.entryService.summary().pipe(
         map((response) => {
+          if(!response){
+            this.toastrService.warning('Your summary information could not be loaded');
+          }
           return new actions.LoadEntriesSummarySuccess(response);
         }),
         catchError((error) => {

--- a/src/app/modules/time-clock/store/entry.effects.ts
+++ b/src/app/modules/time-clock/store/entry.effects.ts
@@ -45,7 +45,7 @@ export class EntryEffects {
     mergeMap(() =>
       this.entryService.summary().pipe(
         map((response) => {
-          if(!response){
+          if (!response){
             this.toastrService.warning('Your summary information could not be loaded');
           }
           return new actions.LoadEntriesSummarySuccess(response);


### PR DESCRIPTION
Show warning when get summary endpoint return empty data