### PR TITLE
fix: TTA-209 add subscription to login component for redirecting user

### DIFF
--- a/src/app/modules/login/login.component.ts
+++ b/src/app/modules/login/login.component.ts
@@ -64,15 +64,12 @@ export class LoginComponent implements OnInit {
   ngOnInit() {
 
     this.googleAuthSDK();
-    if (this.isProduction && this.azureAdB2CService.isLogin()) {
-        this.router.navigate(['']);
-    } else {
       this.loginService.isLogin().subscribe(isLogin => {
         if (isLogin) {
           this.router.navigate(['']);
         }
       });
-    }
+    
     window.handleCredentialResponse = (response) => {
       const {credential = ''} = response;
       this.featureToggleCookiesService.setCookies();


### PR DESCRIPTION
The purpose of this Pull Request is to redirect the user when his access token expires.

**How?**

I merged the logic that was used in legacy. We subscribe to the login service, and it will unsubscribe if we try to make a request with an expired token. Also, in the token injector HTTP interceptor, I added a pipe that checks if the response is 401 unauthorized. If it is, it will redirect the user to the login page.

**Files changed**

- Login component.ts for the logic mentioned above.
- inject.token.interceptor.ts
- Some files that were failing on the linting.