### PR TITLE
Tta 206 UI creating overlapping entries

### DIFF
--- a/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.spec.ts
+++ b/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.spec.ts
@@ -83,6 +83,38 @@ describe('ProjectListHoverComponent', () => {
     expect(store.dispatch).toHaveBeenCalledWith(jasmine.any(ClockIn));
   });
 
+  it('when the user make a clockin and there is an existing time entry running the user have an alert', () => {
+    component.activeEntry = null;
+    const activitiesMock  = [{
+      id: 'xyz',
+      name: 'test',
+      description : 'test1'
+    }];
+    component.activities = activitiesMock;
+    spyOn(store, 'dispatch');
+
+    component.clockIn(1, 'customer', 'project');
+
+    expect(store.dispatch).toHaveBeenCalledWith(jasmine.any(ClockIn));
+    expect(component.canMarkEntryAsWIP).toBe(true);
+  });
+
+  it('when the user make a clockin and there is not an existing time entry running the user can make a clokin', () => {
+    component.activeEntry = null;
+    const activitiesMock  = [{
+      id: 'xyz',
+      name: 'test',
+      description : 'test1'
+    }];
+    component.activities = activitiesMock;
+    spyOn(store, 'dispatch');
+
+    component.clockIn(1, 'customer', 'project');
+
+    expect(store.dispatch).toHaveBeenCalledWith(jasmine.any(ClockIn));
+    expect(component.canMarkEntryAsWIP).toBe(false);
+  });
+
   it('dispatch a UpdateEntryRunning action on updateProject', () => {
     component.activeEntry = { id: '123' };
     spyOn(store, 'dispatch');

--- a/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
+++ b/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
@@ -119,11 +119,13 @@ export class ProjectListHoverComponent implements OnInit, OnDestroy {
     this.store.pipe(select(getTimeEntriesDataSource)).subscribe(ds => {
       this.canMarkEntryAsWIP = !this.isThereAnEntryRunning(ds.data);
     });
-    this.store.dispatch(new entryActions.ClockIn(entry));
-    this.projectsForm.setValue({ project_id: `${customerName} - ${name}` });
-    setTimeout(() => {
-      this.store.dispatch(new actions.LoadRecentProjects());
-    }, 2000);
+    if ( this.canMarkEntryAsWIP){
+      this.store.dispatch(new entryActions.ClockIn(entry));
+      this.projectsForm.setValue({ project_id: `${customerName} - ${name}` });
+      setTimeout(() => {
+        this.store.dispatch(new actions.LoadRecentProjects());
+      }, 2000);
+    }
   }
 
   getEntryRunning(entries: Entry[]) {

--- a/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
+++ b/src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts
@@ -119,13 +119,15 @@ export class ProjectListHoverComponent implements OnInit, OnDestroy {
     this.store.pipe(select(getTimeEntriesDataSource)).subscribe(ds => {
       this.canMarkEntryAsWIP = !this.isThereAnEntryRunning(ds.data);
     });
-    if ( this.canMarkEntryAsWIP){
-      this.store.dispatch(new entryActions.ClockIn(entry));
-      this.projectsForm.setValue({ project_id: `${customerName} - ${name}` });
-      setTimeout(() => {
-        this.store.dispatch(new actions.LoadRecentProjects());
-      }, 2000);
+    if (this.canMarkEntryAsWIP !== false ){
+      this.toastrService.error('There is an existing time entry running please check your time entries')
+      return;
     }
+    this.store.dispatch(new entryActions.ClockIn(entry));
+    this.projectsForm.setValue({ project_id: `${customerName} - ${name}` });
+    setTimeout(() => {
+      this.store.dispatch(new actions.LoadRecentProjects());
+    }, 2000);
   }
 
   getEntryRunning(entries: Entry[]) {


### PR DESCRIPTION
## Description

- When you make a clockinfrom slack, the UI  doesn’t validate if there are running time entries, so in this PR implement this validation in the function clockin()

## Files changed

- src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.spec.ts
- src/app/modules/time-clock/components/project-list-hover/project-list-hover.component.ts

## Task board

- [TTA-206](https://ioetec.atlassian.net/browse/TTA-206?atlOrigin=eyJpIjoiMDQzMjM0YTU4YWFlNDRkNThiMDk3NmQ2OWMxNmYwNTgiLCJwIjoiaiJ9)

## Acceptance criteria

-  When the user tries to clock in on the web app having an ongoing time entry previously created on the Slackbot, it doesn’t start a new entry.
- When the user tries to clock in on the web app having an ongoing time entry previously created on the Slackbot, it shows the user a message saying “You have already clocked in.“