### PR TITLE
refactor: TTA-232-change-warning-message-when-entries-summary-are-not…

### DIFF
--- a/src/app/modules/time-clock/store/entry.effects.ts
+++ b/src/app/modules/time-clock/store/entry.effects.ts
@@ -46,7 +46,7 @@ export class EntryEffects {
       this.entryService.summary().pipe(
         map((response) => {
           if (!response){
-            this.toastrService.warning('Your summary information could not be loaded');
+            this.toastrService.warning("Hey! you don't have any time entries this month yet.");
           }
           return new actions.LoadEntriesSummarySuccess(response);
         }),

--- a/src/app/modules/time-clock/store/entry.effects.ts
+++ b/src/app/modules/time-clock/store/entry.effects.ts
@@ -46,7 +46,7 @@ export class EntryEffects {
       this.entryService.summary().pipe(
         map((response) => {
           if (!response){
-            this.toastrService.warning("Hey! you don't have any time entries this month yet.");
+            this.toastrService.warning("We start a new month! You don't have any time entries yet.");
           }
           return new actions.LoadEntriesSummarySuccess(response);
         }),

--- a/src/app/modules/time-clock/store/entry.effects.ts
+++ b/src/app/modules/time-clock/store/entry.effects.ts
@@ -46,7 +46,7 @@ export class EntryEffects {
       this.entryService.summary().pipe(
         map((response) => {
           if (!response){
-            this.toastrService.warning("We start a new month! You don't have any time entries yet.");
+            this.toastrService.warning("It's a brand new month! You don't have any time entries yet.");
           }
           return new actions.LoadEntriesSummarySuccess(response);
         }),


### PR DESCRIPTION
## Description

- There is a lot of confusion when a user gets this warning. They usually think that the app broke. We need to differentiate a 204 response (no content) from a 400/500 error when the request is not successful.

## Files changed
- src/app/modules/time-clock/store/entry.effects.ts

## Task board

- [TTA-232](https://ioetec.atlassian.net/browse/TTA-232)

## Acceptance criteria

- **Given** the time-clock page **when** user has not created any time entry in the month **then** a warning will appear with the following sentence _Hey! you don't have any time entries this month yet._
