### PR TITLE
fix: TTL-727-bug-fix-error-400-on-project-update-function

### DIFF
--- a/src/app/modules/customer-management/components/projects/components/store/project.effects.ts
+++ b/src/app/modules/customer-management/components/projects/components/store/project.effects.ts
@@ -108,7 +108,7 @@ export class ProjectEffects {
     mergeMap((projectId) =>
       this.projectService.deleteProject(projectId).pipe(
         map(() => {
-          this.toastrService.success(INFO_DELETE_SUCCESSFULLY);
+          this.toastrService.success(INFO_SAVED_SUCCESSFULLY);
           return new actions.DeleteProjectSuccess(projectId);
         }),
         catchError((error) => {


### PR DESCRIPTION
## Description

- When editing a project, if we select it as inactive, we get a 400 HTTP error. The message of the response is "Incorrect body"

## Files changed
- time_tracker/projects/_domain/project.py

## Task board

- [TTL-727](https://ioetec.atlassian.net/browse/TTL-727)

## Acceptance criteria

- Given a TT admin, when they want to select a project as inactive, then the status code of the HTTP request should be 200.
