### PR TITLE
feat: TTL-815-test-calendar-view-feature-toggle

### DIFF
--- a/src/app/modules/time-entries/pages/time-entries.component.html
+++ b/src/app/modules/time-entries/pages/time-entries.component.html
@@ -3,7 +3,7 @@
         <button type="button" (click)="newEntry()" data-toggle="modal" data-target="#editRecordsByDate" class="btn btn-primary">
       Add new entry
     </button>
-        <button type="button" (click)="onDisplayModeChange()" class="btn btn-primary float-right" *ngIf="isFeatureToggleCalendarActive">
+        <button type="button" (click)="onDisplayModeChange()" class="btn btn-primary float-right">
       <em class="fas fa-list" *ngIf="displayGridView"></em>
       <em class="fas fa-th" *ngIf="!displayGridView"></em>
     </button>

--- a/src/app/modules/time-entries/pages/time-entries.component.spec.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.spec.ts
@@ -510,31 +510,6 @@ describe('TimeEntriesComponent', () => {
     expect(cookieService.get).toHaveBeenCalledWith(sentParameter);
   });
 
-  it('set false in isFeatureToggleCalendarActive when cookie does not exist', () => {
-    spyOn(cookieService, 'get');
-
-    component.ngOnInit();
-
-    expect(component.isFeatureToggleCalendarActive).toBeFalse();
-  });
-
-  it('set true in isFeatureToggleCalendarActive when cookiesService.get() return true', () => {
-    const cookieResponseValue = 'true';
-    spyOn(cookieService, 'get').and.returnValue(cookieResponseValue);
-
-    component.ngOnInit();
-
-    expect(component.isFeatureToggleCalendarActive).toBeTrue();
-  });
-
-  it('set false in isFeatureToggleCalendarActive when cookiesService.get() return false', () => {
-    const cookieResponseValue = 'false';
-    spyOn(cookieService, 'get').and.returnValue(cookieResponseValue);
-
-    component.ngOnInit();
-
-    expect(component.isFeatureToggleCalendarActive).toBeFalse();
-  });
 
   it('set true in displayGridView when its initial value is false and call onDisplayModeChange', () => {
     const expectedValue = true;
@@ -642,51 +617,6 @@ describe('TimeEntriesComponent', () => {
     };
     component.changeView(eventView);
     expect(component.calendarView).toBe(CalendarView.Month);
-  });
-
-  it('not view button onDisplayModeChange when isFeatureToggleCalendarActive is false', () => {
-    component.isFeatureToggleCalendarActive = false;
-
-    fixture.detectChanges();
-
-    const HTMLTimeEntriesDebugElement: DebugElement = fixture.debugElement;
-    const HTMLTimeEntriesElement: HTMLElement = HTMLTimeEntriesDebugElement.nativeElement;
-    const HTMLTimeEntriesButton = HTMLTimeEntriesElement.querySelector('.btn.btn-primary.float-right');
-    expect(HTMLTimeEntriesButton).toBeNull();
-  });
-
-  it('view list button when displayGridView is true and isFeatureToggleCalendarActive is true', () => {
-    const expectedIconInsideButton = '.fa-list';
-    const unexpectedIconInsideButton = '.fa-th';
-    component.isFeatureToggleCalendarActive = true;
-    component.displayGridView = true;
-
-    fixture.detectChanges();
-
-    const HTMLTimeEntriesDebugElement: DebugElement = fixture.debugElement;
-    const HTMLTimeEntriesElement: HTMLElement = HTMLTimeEntriesDebugElement.nativeElement;
-    const HTMLTimeEntriesButton = HTMLTimeEntriesElement.querySelector('.btn.btn-primary.float-right');
-    const HTMLExpectedChildButton = HTMLTimeEntriesButton.querySelector(expectedIconInsideButton);
-    const HTMLUnexpectedChildButton = HTMLTimeEntriesButton.querySelector(unexpectedIconInsideButton);
-    expect(HTMLExpectedChildButton).not.toBeNull();
-    expect(HTMLUnexpectedChildButton).toBeNull();
-  });
-
-  it('view calendar button when displayGridView is false and isFeatureToggleCalendarActive is true', () => {
-    const expectedIconInsideButton = '.fa-th';
-    const unexpectedIconInsideButton = '.fa-list';
-    component.isFeatureToggleCalendarActive = true;
-    component.displayGridView = false;
-
-    fixture.detectChanges();
-
-    const HTMLTimeEntriesDebugElement: DebugElement = fixture.debugElement;
-    const HTMLTimeEntriesElement: HTMLElement = HTMLTimeEntriesDebugElement.nativeElement;
-    const HTMLTimeEntriesButton = HTMLTimeEntriesElement.querySelector('.btn.btn-primary.float-right');
-    const HTMLExpectedChildButton = HTMLTimeEntriesButton.querySelector(expectedIconInsideButton);
-    const HTMLUnexpectedChildButton = HTMLTimeEntriesButton.querySelector(unexpectedIconInsideButton);
-    expect(HTMLExpectedChildButton).not.toBeNull();
-    expect(HTMLUnexpectedChildButton).toBeNull();
   });
 
   it('view calendarView when displayGridView is true', () => {

--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -14,7 +14,6 @@ import { EntryState } from '../../time-clock/store/entry.reducer';
 import { EntryActionTypes } from './../../time-clock/store/entry.actions';
 import { getActiveTimeEntry, getTimeEntriesDataSource } from './../../time-clock/store/entry.selectors';
 import { CookieService } from 'ngx-cookie-service';
-import { FeatureToggle } from './../../../../environments/enum';
 import { CalendarView } from 'angular-calendar';
 import { ParseDateTimeOffset } from '../../shared/formatters/parse-date-time-offset/parse-date-time-offset';
 
@@ -43,7 +42,6 @@ export class TimeEntriesComponent implements OnInit, OnDestroy, AfterViewInit {
   wasEditingExistingTimeEntry = false;
   canMarkEntryAsWIP = true;
   timeEntriesDataSource$: Observable<DataSource<Entry>>;
-  isFeatureToggleCalendarActive: boolean;
   displayGridView: boolean;
   selectedDate: moment.Moment;
   selectedYearAsText: string;
@@ -68,7 +66,6 @@ export class TimeEntriesComponent implements OnInit, OnDestroy, AfterViewInit {
 
   ngOnInit(): void {
     this.loadActiveEntry();
-    this.isFeatureToggleCalendarActive = (this.cookiesService.get(FeatureToggle.TIME_TRACKER_CALENDAR) === 'true');
     this.entriesSubscription = this.actionsSubject$.pipe(
       filter((action: any) => (
         action.type === EntryActionTypes.CREATE_ENTRY_SUCCESS ||


### PR DESCRIPTION
## Description

- Test manually calendar view feature toogle in order to relase the feature to all users.

- Remove feature toogle flags.

## Files changed

- src/app/modules/time-entries/pages/time-entries.component.html
- src/app/modules/time-entries/pages/time-entries.component.spec.ts
- src/app/modules/time-entries/pages/time-entries.component.ts

## Task board

- [TTL-815](https://ioetec.atlassian.net/browse/TTL-815)

## Acceptance criteria

- Given time tracker ui when time entries page load then Calendar view button appear on the upper right side
- Given Calendar view when click on a time entry then a modal to eddit time entry appear
- Given Calendar view when click on remove button then a modal to confirm appear
- Given Calendar view when click on week view then you can see the time entries per week
- Given Calendar view when click on day view then you can see the time entries per day
- Given Calendar view when click on month view then you can see the time entries per month
- Given Calendar view when click on list button (appear on the upper right side) then The time entries appear as a list view


[TTL-815]: https://ioetec.atlassian.net/browse/TTL-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ