### PR TITLE
[TTL-746] Deactivate Legacy Pipelines

### DIFF
--- a/.github/workflows/CD-time-tracker-ui.yml
+++ b/.github/workflows/CD-time-tracker-ui.yml
@@ -3,11 +3,7 @@
 
 name: CD process to deploy to App-Service service
 
-on:
-  # Trigger the workflow on pull request but only for the master branch
-  push:
-    branches:
-      - master
+on: workflow_dispatch  # deactivate workflow and run it manually only
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/CD-time-tracker-ui.yml
+++ b/.github/workflows/CD-time-tracker-ui.yml
@@ -1,7 +1,7 @@
 # Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
 # More GitHub Actions for Azure: https://github.com/Azure/actions
 
-name: CD process to deploy to App-Service service
+name: (DEPRECATED) CD process to deploy to App-Service service
 
 on: workflow_dispatch  # deactivate workflow and run it manually only
 

--- a/.github/workflows/CI-mutation-tests.yml
+++ b/.github/workflows/CI-mutation-tests.yml
@@ -1,8 +1,6 @@
 name: Running mutation tests
 
-on:
-  schedule:
-    - cron: '0 9 * * 1'
+on: workflow_dispatch  # deactivate workflow and run it manually only
 
 jobs:
   configuring-stryker:

--- a/.github/workflows/CI-mutation-tests.yml
+++ b/.github/workflows/CI-mutation-tests.yml
@@ -1,4 +1,4 @@
-name: Running mutation tests
+name: (DEPRECATED) Running mutation tests
 
 on: workflow_dispatch  # deactivate workflow and run it manually only
 

--- a/.github/workflows/CI-time-tracker-ui.yml
+++ b/.github/workflows/CI-time-tracker-ui.yml
@@ -1,10 +1,6 @@
 name: CI process for time-tracker app
 
-on:
-  pull_request:
-    types: [opened, edited, reopened, synchronize]
-    branches:
-      - master
+on: workflow_dispatch  # deactivate workflow and run it manually only
 
 jobs:
   # security-audit:

--- a/.github/workflows/CI-time-tracker-ui.yml
+++ b/.github/workflows/CI-time-tracker-ui.yml
@@ -1,4 +1,4 @@
-name: CI process for time-tracker app
+name: (DEPRECATED) CI process for time-tracker app
 
 on: workflow_dispatch  # deactivate workflow and run it manually only
 


### PR DESCRIPTION
Since we changed our infrastructure, we have CI/CD pipelines that achieve the goals that we want right now. The pipelines deactivated in this PR are the legacy ones, and we don't need them anymore.