### PR TITLE
fix: TTL-888 special characters searching tech

### DIFF
--- a/src/app/modules/shared/services/technology.service.spec.ts
+++ b/src/app/modules/shared/services/technology.service.spec.ts
@@ -4,11 +4,12 @@ import { Technology } from '../../shared/models';
 import { TechnologyService } from './technology.service';
 import { STACK_EXCHANGE_ID, STACK_EXCHANGE_ACCESS_TOKEN } from '../../../../environments/environment';
 
-describe('TechnologyService', () => {
+fdescribe('TechnologyService', () => {
   let service: TechnologyService;
   let httpMock: HttpTestingController;
 
   const technologyList: Technology = { items: [{ name: 'java' }, { name: 'javascript' }] };
+  const technologyListWithSpecialChar: Technology = { items: [{ name: 'c#' }, { name: 'c#-2.0' }] };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -42,4 +43,18 @@ describe('TechnologyService', () => {
     expect(getTechnologiesRequest.request.method).toBe('GET');
     getTechnologiesRequest.flush(technologyList);
   });
+
+  it('technologies with special characters are read using GET from url', () => {
+    const technologyFoundSize = technologyListWithSpecialChar.items.length;
+    const technologyName = 'c#';
+    service.getTechnologies(technologyName).subscribe((technologyInResponse) => {
+      expect(technologyInResponse.items.length).toBe(technologyFoundSize);
+    });
+    const getTechnologiesRequest = httpMock.expectOne(
+      `${service.baseUrl}&inname=${encodeURIComponent(technologyName)}&site=stackoverflow&key=${STACK_EXCHANGE_ID}&access_token=${STACK_EXCHANGE_ACCESS_TOKEN}`
+    );
+    expect(getTechnologiesRequest.request.method).toBe('GET');
+    getTechnologiesRequest.flush(technologyListWithSpecialChar);
+  });
+
 });

--- a/src/app/modules/shared/services/technology.service.spec.ts
+++ b/src/app/modules/shared/services/technology.service.spec.ts
@@ -4,7 +4,7 @@ import { Technology } from '../../shared/models';
 import { TechnologyService } from './technology.service';
 import { STACK_EXCHANGE_ID, STACK_EXCHANGE_ACCESS_TOKEN } from '../../../../environments/environment';
 
-fdescribe('TechnologyService', () => {
+describe('TechnologyService', () => {
   let service: TechnologyService;
   let httpMock: HttpTestingController;
 

--- a/src/app/modules/shared/services/technology.service.ts
+++ b/src/app/modules/shared/services/technology.service.ts
@@ -12,7 +12,7 @@ export class TechnologyService {
   constructor(private http: HttpClient) {}
 
   getTechnologies(value: string): Observable<Technology> {
-    const url = `${this.baseUrl}&inname=${value}&site=stackoverflow&key=${STACK_EXCHANGE_ID}&access_token=${STACK_EXCHANGE_ACCESS_TOKEN}`;
+    const url = `${this.baseUrl}&inname=${encodeURIComponent(value)}&site=stackoverflow&key=${STACK_EXCHANGE_ID}&access_token=${STACK_EXCHANGE_ACCESS_TOKEN}`;
     return this.http.get<Technology>(url);
   }
 }


### PR DESCRIPTION
## Description

Allow special characters when searching for technology.

## Files changed

- src/app/modules/shared/services/technology.service.ts

## Task board

- [Technology not found for special caracter](https://ioetec.atlassian.net/browse/TTL-888)
