### PR TITLE
refactor: TTL-866 display times according to current user timezone_offset

### DIFF
--- a/src/app/modules/time-entries/pages/time-entries.component.html
+++ b/src/app/modules/time-entries/pages/time-entries.component.html
@@ -40,7 +40,7 @@
             <tbody *ngIf="!dataSource.isLoading">
                 <tr class="d-flex" *ngFor="let entry of dataSource.data">
                     <td class="col">{{ entry.start_date | date: 'MM/dd/yyyy' }}</td>
-                    <td class="col">{{ dateTimeOffset.parseDateTimeOffset(entry.start_date,entry.timezone_offset) }} - {{ dateTimeOffset.parseDateTimeOffset(entry.end_date,entry.timezone_offset) }}</td>
+                    <td class="col">{{ dateTimeOffset.parseDateTimeOffset(entry.start_date, actualDate.getTimezoneOffset()) }} - {{ dateTimeOffset.parseDateTimeOffset(entry.end_date, actualDate.getTimezoneOffset()) }}</td>
                     <td class="col">{{ entry.end_date | substractDate: entry.start_date }}</td>
                     <td class="col">{{ entry.customer_name }}</td>
                     <td class="col">{{ entry.project_name }}</td>


### PR DESCRIPTION
## Description
Display times according to current user timezone_offset, in Time Entries page, in order for the user to be able to create time entries clearly seeing that they do not overlap.

## Files changed
src/app/modules/time-entries/pages/time-entries.component.html

## Task board

- [address Dylan's bug regarding time zones](https://ioetec.atlassian.net/jira/software/c/projects/TTL/boards/61?modal=detail&selectedIssue=TTL-866)

## Acceptance criteria

- create time entries
- see the time entries in the Time Entries section
    - Change the time zone in your PC, refresh the page, and see how the displayed times change
    - Change the time offset in the entries (editing the DB) and see the displayed times DO NOT change