### PR TITLE
feat: TTL-909 add warning for max time entries

### DIFF
--- a/src/app/modules/time-clock/services/entry.service.ts
+++ b/src/app/modules/time-clock/services/entry.service.ts
@@ -10,6 +10,9 @@ import { DatePipe } from '@angular/common';
 import { Entry } from '../../shared/models';
 import * as moment from 'moment';
 
+
+export const MAX_NUMBER_OF_ENTRIES_FOR_REPORTS = 9999;
+
 @Injectable({
   providedIn: 'root',
 })
@@ -69,7 +72,6 @@ export class EntryService {
   }
 
   loadEntriesByTimeRange(range: TimeEntriesTimeRange, userId: string[] | string ): Observable<any> {
-    const MAX_NUMBER_OF_ENTRIES_FOR_REPORTS = 9999;
     const loadEntriesByTimeRangeURL = this.urlInProductionLegacy ? this.baseUrl : this.baseUrl + '/report/';
     return this.http.get(loadEntriesByTimeRangeURL,
       {

--- a/src/app/modules/time-clock/store/entry.effects.spec.ts
+++ b/src/app/modules/time-clock/store/entry.effects.spec.ts
@@ -401,7 +401,7 @@ describe('TimeEntryActionEffects', () => {
     });
   });
 
-  fit('should show a warning when maximum number of entries is received', async () => {
+  it('should show a warning when maximum number of entries is received', async () => {
     const timeRange: TimeEntriesTimeRange = { start_date: moment(new Date()), end_date: moment(new Date()) };
     const userId = '*';
     const entries = [];

--- a/src/app/modules/time-clock/store/entry.effects.spec.ts
+++ b/src/app/modules/time-clock/store/entry.effects.spec.ts
@@ -13,8 +13,7 @@ import { EntryService, MAX_NUMBER_OF_ENTRIES_FOR_REPORTS } from '../services/ent
 import { INFO_SAVED_SUCCESSFULLY } from './../../shared/messages';
 import { EntryActionTypes, SwitchTimeEntry, DeleteEntry, CreateEntry } from './entry.actions';
 import { EntryEffects } from './entry.effects';
-import { stringify } from 'querystring';
-import { isString } from 'util';
+
 
 describe('TimeEntryActionEffects', () => {
 

--- a/src/app/modules/time-clock/store/entry.effects.ts
+++ b/src/app/modules/time-clock/store/entry.effects.ts
@@ -263,7 +263,7 @@ export class EntryEffects {
           if (response.length >= MAX_NUMBER_OF_ENTRIES_FOR_REPORTS){
             this.toastrService.warning(
               'Still loading. Limit of ' + MAX_NUMBER_OF_ENTRIES_FOR_REPORTS +
-              ' entries reached, try filtering the request by users or date.' +
+              ' entries reached, try filtering the request.' +
               ' Some information may be missing.'
             );
           }

--- a/src/app/modules/time-clock/store/entry.effects.ts
+++ b/src/app/modules/time-clock/store/entry.effects.ts
@@ -5,7 +5,7 @@ import { Action } from '@ngrx/store';
 import { ToastrService } from 'ngx-toastr';
 import { Observable, of } from 'rxjs';
 import { catchError, map, mergeMap, switchMap } from 'rxjs/operators';
-import { EntryService } from '../services/entry.service';
+import { EntryService, MAX_NUMBER_OF_ENTRIES_FOR_REPORTS } from '../services/entry.service';
 import * as actions from './entry.actions';
 import * as moment from 'moment';
 
@@ -241,7 +241,7 @@ export class EntryEffects {
           if (isStartTimeInLastEntry) {
             return new actions.UpdateEntry({ id: lastEntry.id, end_date: entry.start_date });
           } else {
-            this.toastrService.success('You change the time-in successfully');
+            this.toastrService.success('You changed the time-in successfully');
             return new actions.UpdateEntryRunning(entry);
           }
         }),
@@ -260,6 +260,13 @@ export class EntryEffects {
     mergeMap((action) =>
       this.entryService.loadEntriesByTimeRange(action.timeRange, action.userId).pipe(
         map((response) => {
+          if (response.length >= MAX_NUMBER_OF_ENTRIES_FOR_REPORTS){
+            this.toastrService.warning(
+              'Still loading. Limit of ' + MAX_NUMBER_OF_ENTRIES_FOR_REPORTS +
+              ' entries reached, try filtering the request by users or date.' +
+              ' Some information may be missing.'
+            );
+          }
           return new actions.LoadEntriesByTimeRangeSuccess(response);
         }),
         catchError((error) => {


### PR DESCRIPTION
## Description

Show a warning when the number of time entries retrieved from the backend reach the limit.

## Files changed

- src/app/modules/time-clock/services/entry.service.ts
- src/app/modules/time-clock/store/entry.effects.spec.ts
- src/app/modules/time-clock/store/entry.effects.ts

## Task board

- [TTL-909](https://ioetec.atlassian.net/browse/TTL-909)


[TTL-909]: https://ioetec.atlassian.net/browse/TTL-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ