### PR TITLE
fix: TTL-836 customer duplicated error message

### DIFF
--- a/src/app/modules/customer-management/store/customer-management.effects.spec.ts
+++ b/src/app/modules/customer-management/store/customer-management.effects.spec.ts
@@ -10,7 +10,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ToastrModule, ToastrService } from 'ngx-toastr';
 import { INFO_SAVED_SUCCESSFULLY, INFO_DELETE_SUCCESSFULLY } from '../../shared/messages';
 
-describe('CustomerEffects', () => {
+fdescribe('CustomerEffects', () => {
   let actions$: Observable<Action>;
   let effects: CustomerEffects;
   let service: CustomerService;
@@ -88,11 +88,12 @@ describe('CustomerEffects', () => {
 
   it('action type is CREATE_CUSTOMER_FAIL when service fail in execution', async () => {
     actions$ = of({ type: CustomerManagementActionTypes.CREATE_CUSTOMER, payload: customer });
+
     spyOn(toastrService, 'error');
-    spyOn(service, 'createCustomer').and.returnValue(throwError({ error: { message: 'fail!' } }));
+    spyOn(service, 'createCustomer').and.returnValue(throwError({ error: 'Duplicated' }));
 
     effects.createCustomer$.subscribe((action) => {
-      expect(toastrService.error).toHaveBeenCalled();
+      expect(toastrService.error).toHaveBeenCalledWith('Duplicated');
       expect(action.type).toEqual(CustomerManagementActionTypes.CREATE_CUSTOMER_FAIL);
     });
   });

--- a/src/app/modules/customer-management/store/customer-management.effects.spec.ts
+++ b/src/app/modules/customer-management/store/customer-management.effects.spec.ts
@@ -10,7 +10,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ToastrModule, ToastrService } from 'ngx-toastr';
 import { INFO_SAVED_SUCCESSFULLY, INFO_DELETE_SUCCESSFULLY } from '../../shared/messages';
 
-fdescribe('CustomerEffects', () => {
+describe('CustomerEffects', () => {
   let actions$: Observable<Action>;
   let effects: CustomerEffects;
   let service: CustomerService;

--- a/src/app/modules/customer-management/store/customer-management.effects.ts
+++ b/src/app/modules/customer-management/store/customer-management.effects.ts
@@ -1,4 +1,4 @@
-import { INFO_SAVED_SUCCESSFULLY, INFO_DELETE_SUCCESSFULLY, DUPLICATED_ERROR } from '../../shared/messages';
+import { INFO_SAVED_SUCCESSFULLY, INFO_DELETE_SUCCESSFULLY } from '../../shared/messages';
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Action } from '@ngrx/store';

--- a/src/app/modules/customer-management/store/customer-management.effects.ts
+++ b/src/app/modules/customer-management/store/customer-management.effects.ts
@@ -1,4 +1,4 @@
-import { INFO_SAVED_SUCCESSFULLY, INFO_DELETE_SUCCESSFULLY } from '../../shared/messages';
+import { INFO_SAVED_SUCCESSFULLY, INFO_DELETE_SUCCESSFULLY, DUPLICATED_ERROR } from '../../shared/messages';
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Action } from '@ngrx/store';
@@ -46,7 +46,7 @@ export class CustomerEffects {
           return new actions.CreateCustomerSuccess(customerData);
         }),
         catchError((error) => {
-          this.toastrService.error(error.error.message);
+          this.toastrService.error(error.error);
           return of(new actions.CreateCustomerFail(error));
         })
       )


### PR DESCRIPTION
## Description

Fix empty message when trying to save a new customer whose name already exist

## Files changed

- src/app/modules/customer-management/store/customer-management.effects.spec.ts
- src/app/modules/customer-management/store/customer-management.effects.ts

## Task board

- [TTL-836](https://ioetec.atlassian.net/browse/TTL-836)

## Acceptance criteria

Message when trying to save a new customer whose name already exist is 'Duplicated'


[TTL-836]: https://ioetec.atlassian.net/browse/TTL-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ