### PR TITLE
feat: TTL-925 update overlap message

### DIFF
--- a/src/app/modules/time-entries/pages/time-entries.component.ts
+++ b/src/app/modules/time-entries/pages/time-entries.component.ts
@@ -146,7 +146,7 @@ export class TimeEntriesComponent implements OnInit, OnDestroy, AfterViewInit {
       this.checkIfActiveEntryOverlapping(isEditingEntryEqualToActiveEntry, startDateAsLocalDate);
       if (!isEditingEntryEqualToActiveEntry && isTimeEntryOverlapping || this.isActiveEntryOverlapping ) {
         const message = this.isActiveEntryOverlapping ? 'try another "Time in"' : 'try with earlier times';
-        this.toastrService.error(`You are on the clock and this entry overlaps it, ${message}.`);
+        this.toastrService.error(`There is an overlap with another time entry, please modify the time.`);
         this.isActiveEntryOverlapping = false;
       } else {
         this.doSave(event);


### PR DESCRIPTION
## Description

This PR modifies the error message showed when a running time entry is modified and the time in overlaps with another time entry.

## Files changed

src/app/modules/time-entries/pages/time-entries.component.ts

## Task board

- [TTL-925](https://ioetec.atlassian.net/jira/software/c/projects/TTL/boards/61?modal=detail&selectedIssue=TTL-925)


[TTL-925]: https://ioetec.atlassian.net/browse/TTL-925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ